### PR TITLE
fix: last listed app not being backed up

### DIFF
--- a/conf/backup-with-borg.j2
+++ b/conf/backup-with-borg.j2
@@ -30,7 +30,14 @@ fi
 # Backup all apps independently
 apps=$(yunohost app setting {{ app }} apps)
 for app in $(yunohost app list --installed -b | grep id: | cut -d: -f2); do
-    if [[ "$apps" = *"$app,"* ]] || [ "$apps" = "all" ]; then
+    backup_app=false
+    for selected_app in $(echo $apps | tr "," " ");do
+        if [[ "$selected_app" == "$app" ]] || [ "$apps" = "all" ]; then
+          backup_app=true
+          break
+        fi
+    done
+    if [ "$backup_app" == "true" ];then
         yunohost backup create $ignore_system -n auto_$app --method {{ app }}_app --apps $app
     fi
 done


### PR DESCRIPTION
I noticed that with the current check the last app of the list given during installation was not being backed up.

Indeed, if the list looks like "app1,app2,app3", the check `[[ "$apps" = *"$app,"* ]]` will match app1 and app2 but not app3.

What I suggest fixes this issue, we split the list and check each element independently.