### PR TITLE
Add timestamp to logs, and log only to backup_borg.err

### DIFF
--- a/conf/backup_method.j2
+++ b/conf/backup_method.j2
@@ -14,6 +14,11 @@ do_need_mount() {
     true
 }
 
+LOGFILE=/var/log/backup_borg.err
+log_with_timestamp() {
+  sed -e "s/^/[$(date +"%Y-%m-%d_%H:%M:%S")] /" >> $LOGFILE
+}
+
 do_backup() {
     
     export BORG_PASSPHRASE
@@ -23,12 +28,10 @@ do_backup() {
     repo=$3
     size=$4
     description=$5
-    LOGFILE=/var/log/backup_borg.log
-    ERRFILE=/var/log/backup_borg.err
     current_date=$(date +"%d_%m_%y_%H:%M")
     pushd $work_dir
     set +e
-    if borg init -e repokey $repo >> $LOGFILE 2>> $ERRFILE; then
+    if borg init -e repokey $repo 2>&1 >/dev/null | log_with_timestamp; then
 	    #human_size=`echo $size | awk '{ suffix=" KMGT"; for(i=1; $1>1024 && i < length(suffix); i++) $1/=1024; print int($1) substr(suffix, i, 1), $3; }'`
 	    # Speed in Kbps
 	    #speed=1000
@@ -41,10 +44,10 @@ This is an automated message from your beloved YunoHost server." | /usr/bin/mail
     fi
     set -e
 
-    borg create $repo::${name}_${current_date} ./ >> $LOGFILE 2>> $ERRFILE
+    borg create $repo::${name}_${current_date} ./ 2>&1 >/dev/null | log_with_timestamp
     popd
 
-    borg prune $repo -P ${name} --keep-hourly 2 --keep-daily=7 --keep-weekly=8 --keep-monthly=12 >> $LOGFILE 2>> $ERRFILE
+    borg prune $repo -P ${name} --keep-hourly 2 --keep-daily=7 --keep-weekly=8 --keep-monthly=12 2>&1 >/dev/null | log_with_timestamp
 }
 
 do_mount() {
@@ -55,9 +58,7 @@ do_mount() {
     repo=$3
     size=$4
     description=$5
-    LOGFILE=/var/log/backup_borg.log
-    ERRFILE=/var/log/backup_borg.err
-    borg mount $repo::$name $work_dir >> $LOGFILE 2>> $ERRFILE
+    borg mount $repo::$name $work_dir 2>&1 >/dev/null | log_with_timestamp
 }
 
 work_dir=$2


### PR DESCRIPTION
A possible solution to the two remarks in #26.
The `2>&1 >/dev/null` syntax allows to redirect stderr to stdout and therefore being able to pipe it and add timestamps before appending to log file. Logging stderr only should be enough since stdout is not used by the borg command.