### PR TITLE
Added option to chose when to receive email alerts

### DIFF
--- a/conf/backup-with-borg
+++ b/conf/backup-with-borg
@@ -77,7 +77,7 @@ mailalert="$(sudo yunohost app setting ${borg_id} mailalert)"
 if [[ ! -z "$errors" && $mailalert != "never" ]]; then
     cat <(echo -e "$errors\n\n\n") "$log_file" "$err_file" | mail -s "[borg] Backup failed from $domain onto $repository" root
     exit 1
-else if [ $mailalert == "always" ]
+elif [ $mailalert == "always" ]
     cat $log_file | mail -s "[borg] Backup succeed from $domain onto $repository" root
     exit 0
 fi

--- a/conf/backup-with-borg
+++ b/conf/backup-with-borg
@@ -73,10 +73,11 @@ fi
 # Send mail on backup (partially) failed
 domain=$(hostname)
 repository="$(sudo yunohost app setting ${borg_id} repository)"
-if [ ! -z "$errors" ]; then
+mailalert="$(sudo yunohost app setting ${borg_id} mailalert)"
+if [[ ! -z "$errors" && $mailalert != "never" ]]; then
     cat <(echo -e "$errors\n\n\n") "$log_file" "$err_file" | mail -s "[borg] Backup failed from $domain onto $repository" root
     exit 1
-else
+else if [ $mailalert == "always" ]
     cat $log_file | mail -s "[borg] Backup succeed from $domain onto $repository" root
     exit 0
 fi

--- a/manifest.json
+++ b/manifest.json
@@ -85,6 +85,15 @@
                 },
                 "example": "Monthly or Weekly or Daily or Hourly or 4:00 or 5,17:00  or Sat --1..7 18:00:00",
                 "default": "Daily"
+            },
+            {
+                "name": "mailalert",
+                "type": "string",
+                "ask": {
+                    "en": "Do you want admin to receive mail notifications on backups ?",
+                    "fr": "Souhaitez-vous recevoir des notifications par mail à chaque sauvegarde ?"
+                },
+                "choices": ["always", "errors_only", "never"]
             }
         ]
     }

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -24,6 +24,10 @@ export conf="$(ynh_app_setting_get $app conf)"
 export data="$(ynh_app_setting_get $app data)"
 export apps="$(ynh_app_setting_get $app apps)"
 export mailalert="$(ynh_app_setting_get $app mailalert)"
+if [[ $mailalert != "always" && $mailalert != "errors_only" && $mailalert != "never" ]]; then
+	ynh_app_setting_set --app=$app --key="mailalert" --value="errors_only"
+	export mailalert="errors_only"
+fi
 
 #=================================================
 # CHECK IF AN UPGRADE IS NEEDED

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -23,6 +23,7 @@ export on_calendar="$(ynh_app_setting_get $app on_calendar)"
 export conf="$(ynh_app_setting_get $app conf)"
 export data="$(ynh_app_setting_get $app data)"
 export apps="$(ynh_app_setting_get $app apps)"
+export mailalert="$(ynh_app_setting_get $app mailalert)"
 
 #=================================================
 # CHECK IF AN UPGRADE IS NEEDED


### PR DESCRIPTION
It's really cool to receive email notifications when there are some backup errors, but daily receiving success email is not always necessary.
This patch is a proposal to give the admins the choice when installing if to receive email alerts. Alternatively, the option could also just be a hidden one, set to "always" by default in install script, and documented somewhere for people who want more fine control.