### PR TITLE
Upgrade setuptools to avoid issue with egg_info

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -17,6 +17,7 @@ install_borg_with_pip () {
     if [ ! -d /opt/borg-env ]; then
         python3 -m venv /opt/borg-env
         /opt/borg-env/bin/python /opt/borg-env/bin/pip install pip -U
+        /opt/borg-env/bin/python /opt/borg-env/bin/pip install -U setuptools
         /opt/borg-env/bin/python /opt/borg-env/bin/pip install wheel
         ynh_print_info --message="Installing/compiling borg, this may take some time..."
         /opt/borg-env/bin/python /opt/borg-env/bin/pip install borgbackup[fuse]==$BORG_VERSION


### PR DESCRIPTION
## Problem

- I cannot install borg_ynh, because:

```
Attention :   Cache entry deserialization failed, entry ignored
Attention : Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-rfl1lboe/borgbackup/
Erreur : Impossible d’installer borg : Une erreur est survenue dans le script d’installation de l’application
```

## Solution

- Upgrade setuptools, as explained here: https://appuals.com/command-python-setup-py-egg_info/

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
