### PR TITLE
Also display error messages in backup create output

### DIFF
--- a/conf/backup_method
+++ b/conf/backup_method
@@ -18,7 +18,7 @@ do_need_mount() {
 
 LOGFILE=/var/log/backup_borg.err
 log_with_timestamp() {
-  sed -e "s/^/[$(date +"%Y-%m-%d_%H:%M:%S")] /" >> $LOGFILE
+  sed -e "s/^/[$(date +"%Y-%m-%d_%H:%M:%S")] /" | tee -a $LOGFILE
 }
 
 do_backup() {


### PR DESCRIPTION
## Problem

When backup miserably crashes, errors are only logged in /var/log/borg_backup.err, but don't appear in Yunohost log operation

## Solution

Use tee -a to have the error stream both in stdout and the error log file

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
