### PR TITLE
Remove failing test.

### DIFF
--- a/check_process
+++ b/check_process
@@ -41,7 +41,6 @@
 		multi_instance=1
 		port_already_use=0
 		change_url=0
-;;; Upgrade options
-	; commit=d1cd666ee27f5cfb8e40c6f44a09370381b41b35
-		name=Older ynh 11 version 
-		manifest_arg=server=domain.tld:22&ssh_user=package_checker&passphrase=APassphrase&conf=1&data=1&apps=all&on_calendar=Daily&mailalert=never
+;;; Options
+Email=
+Notification=none


### PR DESCRIPTION
## Problem

- `borg` is marked [bork](https://www.merriam-webster.com/dictionary/borked)__ed__.

## Solution

- Remove failing test, its version to upgrade from is incompatible with `bullseye`.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
