### PR TITLE
Support multiple repositories (values separated by `;`)

### DIFF
--- a/conf/backup_method
+++ b/conf/backup_method
@@ -5,12 +5,17 @@ app="${0#"./05-"}"
 app="${app%"_app"}"
 
 BORG_PASSPHRASE="$(yunohost app setting $app passphrase)"
-repo="$(yunohost app setting $app repository)"   #$4
+repos="$(yunohost app setting $app repository)"   #$4
 if ssh-keygen -F "__SERVER__" >/dev/null ; then
     BORG_RSH="ssh -i /root/.ssh/id_${app}_ed25519 -oStrictHostKeyChecking=yes "
 else
     BORG_RSH="ssh -i /root/.ssh/id_${app}_ed25519 -oStrictHostKeyChecking=no "
 fi
+
+sanitize_repo() {
+  repo="$1"
+  echo "$repo" | sed "s/(^\s*|\s*$)//g" # Trim the spaces
+}
 
 do_need_mount() {
     true
@@ -78,15 +83,21 @@ name="$3"
 size="$5"
 description="$6"
 
+saveIFS="$IFS"
+IFS=$';' array_repos=($repos)
+IFS="$saveIFS"
+
 case "$1" in
   need_mount)
-    do_need_mount "$work_dir" "$name" "$repo" "$size" "$description"
+    do_need_mount "$work_dir" "$name" "$(sanitize_repo "$array_repos[0]")" "$size" "$description"
     ;;
   backup)
-    do_backup "$work_dir" "$name" "$repo" "$size" "$description"
+    for repo in "${array_repos[@]}"; do
+      do_backup "$work_dir" "$name" "$(sanitize_repo "$repo")" "$size" "$description"
+    done
     ;;
   mount)
-    do_mount
+    do_mount "$work_dir" "$name" "$(sanitize_repo "$array_repos[0]")" "$size" "$description"
     ;;
   *)
     echo "hook called with unknown argument \`$1'" >&2


### PR DESCRIPTION
## Problem

Fixes #146 

When backuping with multiple repositories, you'd have to install twice the borg app.
If I am not wrong, this causes to copy (link) apps data as many times as you have repositories, which can take time depending on the apps being backed up.

## Solution

Instead, this patch proposes to install a single client for multiple repositories.

Note: Probably this PR would need #148, if we'd prefer separating values by newlines instead of semi-colons.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
