### PR TITLE
Misc improvements

### DIFF
--- a/conf/backup_method
+++ b/conf/backup_method
@@ -46,14 +46,9 @@ This is an automated message from your beloved YunoHost server." | /usr/bin/mail
     # About the {now} placeholder:
     # https://borgbackup.readthedocs.io/en/stable/usage/create.html#description
     # In the archive name, you may use the following placeholders: {now}, {utcnow}, {fqdn}, {hostname}, {user} and some others.
-    "$borg" create --stats "::_${name}-{now}" "$work_dir"
+    "$borg" create --stats "::${name}-{now}" "$work_dir"
 
-    # About thi _20 it's a crazy fix to avoid pruning wordpress__2
-    # if you prune wordpress
-    "$borg" prune -P "_${name}-" --list --keep-hourly 2 --keep-daily=7 --keep-weekly=8 --keep-monthly=12
-
-    # Prune legacy archive name without error on wordpress/wordpress__2
-    "$borg" prune -P "${name}_" --list --keep-within 2m --keep-monthly=12
+    "$borg" prune --glob-archives "${name}-*" --list --keep-hourly 2 --keep-daily=7 --keep-weekly=8 --keep-monthly=12
 
     # We prune potential manual backup older than 1 year
     "$borg" prune --list --keep-within 1y

--- a/conf/backup_method
+++ b/conf/backup_method
@@ -5,7 +5,8 @@ borg="__INSTALL_DIR__/venv/bin/borg"
 app="__APP__"
 
 BORG_PASSPHRASE="$(yunohost app setting "$app" passphrase)"
-repo="$(yunohost app setting "$app" repository)"   #$4
+BORG_REPO="$(yunohost app setting "$app" repository)"
+BORG_LOGGING_CONF="__INSTALL_DIR__/logging.conf"
 
 if ssh-keygen -F "__SERVER__" >/dev/null ; then
     BORG_RSH="ssh -i /root/.ssh/id_${app}_ed25519 -oStrictHostKeyChecking=yes "
@@ -17,22 +18,16 @@ do_need_mount() {
     true
 }
 
-LOGFILE=/var/log/backup_borg.err
-log_with_timestamp() {
-    sed -e "s/^/[$(date +"%Y-%m-%d_%H:%M:%S")] /" | tee -a $LOGFILE
-}
-
 do_backup() {
     export BORG_PASSPHRASE
+    export BORG_REPO
     export BORG_RSH
+    export BORG_LOGGING_CONF
     export BORG_RELOCATED_REPO_ACCESS_IS_OK=yes
     work_dir="$1"
     name="$2"
-    repo="$3"
-    size="$4"
-    description="$5"
-    current_date=$(date +"%Y-%m-%d_%H:%M")
-    pushd "$work_dir"
+    size="$3"
+    description="$4"
     set +e
     if "$borg" init -e repokey "$repo" ; then
         # human_size=`echo $size | awk '{ suffix=" KMGT"; for(i=1; $1>1024 && i < length(suffix); i++) $1/=1024; print int($1) substr(suffix, i, 1), $3; }'`
@@ -41,35 +36,38 @@ do_backup() {
         # evaluated_time=$(($size / ($speed * 1000 / 8) / 3600))
         echo "Hello,
 
-Your first backup on $repo is starting.
+Your first backup on $BORG_REPO is starting.
 
 This is an automated message from your beloved YunoHost server." | /usr/bin/mail.mailutils -a "Content-Type: text/plain; charset=UTF-8" -s "[YNH] First backup is starting" "root"
     fi
     set -e
 
-    "$borg" create "$repo::_${name}-${current_date}" ./ 2>&1 >/dev/null | log_with_timestamp
-    popd
+    # About the {now} placeholder:
+    # https://borgbackup.readthedocs.io/en/stable/usage/create.html#description
+    # In the archive name, you may use the following placeholders: {now}, {utcnow}, {fqdn}, {hostname}, {user} and some others.
+    "$borg" create "::_${name}-{now}" "$work_dir"
 
     # About thi _20 it's a crazy fix to avoid pruning wordpress__2
     # if you prune wordpress
-    "$borg" prune "$repo" -P "_${name}-" --keep-hourly 2 --keep-daily=7 --keep-weekly=8 --keep-monthly=12 2>&1 >/dev/null | log_with_timestamp
+    "$borg" prune -P "_${name}-" --keep-hourly 2 --keep-daily=7 --keep-weekly=8 --keep-monthly=12
 
     # Prune legacy archive name without error on wordpress/wordpress__2
-    "$borg" prune "$repo" -P "${name}_" --keep-within 2m --keep-monthly=12 2>&1 >/dev/null | log_with_timestamp
+    "$borg" prune -P "${name}_" --keep-within 2m --keep-monthly=12
 
     # We prune potential manual backup older than 1 year
-    "$borg" prune "$repo" --keep-within 1y 2>&1 >/dev/null | log_with_timestamp
+    "$borg" prune --keep-within 1y
 }
 
 do_mount() {
     export BORG_PASSPHRASE
+    export BORG_REPO
     export BORG_RSH
+    export BORG_LOGGING_CONF
     work_dir="$1"
     name="$2"
-    repo="$3"
-    size="$4"
-    description="$5"
-    "$borg" mount "$repo::$name" "$work_dir" 2>&1 >/dev/null | log_with_timestamp
+    size="$3"
+    description="$4"
+    "$borg" mount "::$name" "$work_dir"
 }
 
 work_dir="$2"
@@ -80,13 +78,13 @@ description="$6"
 
 case "$1" in
   need_mount)
-    do_need_mount "$work_dir" "$name" "$repo" "$size" "$description"
+    do_need_mount "$work_dir" "$name" "$size" "$description"
     ;;
   backup)
-    do_backup "$work_dir" "$name" "$repo" "$size" "$description"
+    do_backup "$work_dir" "$name" "$size" "$description"
     ;;
   mount)
-    do_mount "$work_dir" "$name" "$repo" "$size" "$description"
+    do_mount "$work_dir" "$name" "$size" "$description"
     ;;
   *)
     echo "hook called with unknown argument \`$1'" >&2

--- a/conf/backup_method
+++ b/conf/backup_method
@@ -29,7 +29,8 @@ do_backup() {
     size="$3"
     description="$4"
     set +e
-    if "$borg" init -e repokey "$repo" ; then
+    if ! "$borg" config -l > /dev/null 2>&1; then
+        "$borg" init -e repokey
         # human_size=`echo $size | awk '{ suffix=" KMGT"; for(i=1; $1>1024 && i < length(suffix); i++) $1/=1024; print int($1) substr(suffix, i, 1), $3; }'`
         # Speed in Kbps
         # speed=1000

--- a/conf/backup_method
+++ b/conf/backup_method
@@ -46,17 +46,17 @@ This is an automated message from your beloved YunoHost server." | /usr/bin/mail
     # About the {now} placeholder:
     # https://borgbackup.readthedocs.io/en/stable/usage/create.html#description
     # In the archive name, you may use the following placeholders: {now}, {utcnow}, {fqdn}, {hostname}, {user} and some others.
-    "$borg" create "::_${name}-{now}" "$work_dir"
+    "$borg" create --stats "::_${name}-{now}" "$work_dir"
 
     # About thi _20 it's a crazy fix to avoid pruning wordpress__2
     # if you prune wordpress
-    "$borg" prune -P "_${name}-" --keep-hourly 2 --keep-daily=7 --keep-weekly=8 --keep-monthly=12
+    "$borg" prune -P "_${name}-" --list --keep-hourly 2 --keep-daily=7 --keep-weekly=8 --keep-monthly=12
 
     # Prune legacy archive name without error on wordpress/wordpress__2
-    "$borg" prune -P "${name}_" --keep-within 2m --keep-monthly=12
+    "$borg" prune -P "${name}_" --list --keep-within 2m --keep-monthly=12
 
     # We prune potential manual backup older than 1 year
-    "$borg" prune --keep-within 1y
+    "$borg" prune --list --keep-within 1y
 }
 
 do_mount() {

--- a/conf/logging.conf
+++ b/conf/logging.conf
@@ -1,0 +1,23 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=logfile
+
+[formatters]
+keys=logfile
+
+[logger_root]
+level=NOTSET
+handlers=logfile
+
+[handler_logfile]
+class=FileHandler
+level=INFO
+formatter=logfile
+args=('/var/log/__APP__/borg.log', 'a')
+
+[formatter_logfile]
+format=%(asctime)s %(levelname)s %(message)s
+datefmt=
+class=logging.Formatter

--- a/scripts/backup
+++ b/scripts/backup
@@ -22,6 +22,9 @@ ynh_backup --src_path="/etc/sudoers.d/$app"
 ynh_backup --src_path="/root/.ssh/id_${app}_ed25519" --not_mandatory
 ynh_backup --src_path="/root/.ssh/id_${app}_ed25519.pub" --not_mandatory
 
+ynh_backup --src_path="$install_dir/backup-with-borg"
+ynh_backup --src_path="$install_dir/logging.conf"
+
 #=================================================
 # END OF SCRIPT
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -71,6 +71,9 @@ chown "$app:$app" "$install_dir/backup-with-borg"
 ynh_add_config --template="sudoer" --destination="/etc/sudoers.d/$app"
 chown root:root "/etc/sudoers.d/$app"
 
+ynh_add_config --template="logging.conf" --destination="$install_dir/logging.conf"
+chown "$app:$app" "$install_dir/logging.conf"
+
 #=================================================
 # SYSTEM CONFIGURATION
 #=================================================
@@ -78,7 +81,7 @@ ynh_script_progression --message="Adding system configurations related to $app..
 
 # Create a dedicated systemd config
 ynh_add_systemd_config
-yunohost service add $app --description="Deduplicating backup program" --test_status="systemctl show $app.service  -p ActiveState --value | grep -v failed"
+yunohost service add $app --description="Deduplicating backup program" --test_status="systemctl show $app.service  -p ActiveState --value | grep -v failed" --log "/var/log/$app/borg.log"
 # Disable the service, this is to prevent the service from being triggered at boot time
 systemctl disable $app.service --quiet
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -37,6 +37,13 @@ chmod go=--- "/etc/yunohost/hooks.d/backup_method/05-${app}_app"
 ynh_restore_file --origin_path="/etc/sudoers.d/$app"
 chown root:root "/etc/sudoers.d/$app"
 
+ynh_restore_file --origin_path="$install_dir/backup-with-borg"
+chmod u+x "$install_dir/backup-with-borg"
+chown "$app:$app" "$install_dir/backup-with-borg"
+
+ynh_restore_file --origin_path="$install_dir/logging.conf"
+chown "$app:$app" "$install_dir/logging.conf"
+
 #=================================================
 # RESTORE SYSTEM CONFIGURATIONS
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -93,6 +93,9 @@ chown "$app:$app" "$install_dir/backup-with-borg"
 ynh_add_config --template="sudoer" --destination="/etc/sudoers.d/$app"
 chown root:root "/etc/sudoers.d/$app"
 
+ynh_add_config --template="logging.conf" --destination="$install_dir/logging.conf"
+chown "$app:$app" "$install_dir/logging.conf"
+
 #=================================================
 # REAPPLY SYSTEM CONFIGURATIONS
 #=================================================
@@ -100,7 +103,7 @@ ynh_script_progression --message="Upgrading system configurations related to $ap
 
 # Create a dedicated systemd config
 ynh_add_systemd_config
-yunohost service add $app --description="Deduplicating backup program" --test_status="systemctl show $app.service  -p ActiveState --value | grep -v failed"
+yunohost service add $app --description="Deduplicating backup program" --test_status="systemctl show $app.service  -p ActiveState --value | grep -v failed"  --log "/var/log/$app/borg.log"
 # Disable the service, this is to prevent the service from being triggered at boot time
 systemctl disable $app.service --quiet
 


### PR DESCRIPTION
## Problem

- *Description of why you made this PR*

## Solution

- *Use `BORG_REPO` env var instead of using `$repo` all over the place*
- *Use `logging.conf` file, and the corresponding env var to manage logs instead of using `| tee -a`*
- *Replace `borg prune -P` with `borg prune --glob-archives "regex"` because -P is deprecated, and it should fix the mess about pruning `app` and `apps__2` (tested on my side by spamming `systemctl start borg.service`)*
- *Avoid a false error message about repo already exists*
- *Add `--stats` and `--list` to have more infos in logs*
- *Backup/restore `backup-with-borg` (I think there was a problem here, after a restore the `backup-with-borg` file shouldn't exist if I read the code correctly)*
- *Add the log file `/var/log/$app/borg.log` to the ynh service to be able to see the logs in the webadmin*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
