### PR TITLE
Update 1.2.8.md

### DIFF
--- a/doc/POST_UPGRADE.d/1.2.8.md
+++ b/doc/POST_UPGRADE.d/1.2.8.md
@@ -1,7 +1,7 @@
 [Borg pre-version 1.2.5 had CVE in archive format](https://github.com/borgbackup/borg/blob/1.2.8/docs/changes.rst#pre-125-archives-spoofing-vulnerability-cve-2023-36811). One liner to check if you're affected is:
 
 ```sh
-sudo env BORG_RSH="ssh -i /root/.ssh/id___APP___ed25519 -oStrictHostKeyChecking=yes " BORG_PASSPHRASE="$(sudo yunohost app setting __APP__ passphrase)" BORG_RELOCATED_REPO_ACCESS_IS_OK=yes BORG_REPO="$(sudo yunohost app setting __APP__ repository)" __INSTALL_DIR__/venv/bin/borg upgrade --show-rc --check-tam $BORG_REPO
+sudo env BORG_RSH="ssh -i /root/.ssh/id___APP___ed25519 -p 22 -oStrictHostKeyChecking=yes " BORG_PASSPHRASE="$(sudo yunohost app setting __APP__ passphrase)" BORG_RELOCATED_REPO_ACCESS_IS_OK=yes BORG_REPO="$(sudo yunohost app setting __APP__ repository)" __INSTALL_DIR__/venv/bin/borg upgrade --show-rc --check-tam $BORG_REPO
 ```
 
 Consult the linked documentation on how to interpret the result.


### PR DESCRIPTION
Add option for port (easier to see where to change if user use a custom port).

## Problem

An user with a custom ssh port don't see where to change it in the command. 

## Solution

I add "-p 22", I think it simpler to see where it's possible to specify a custom port.

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
