### PR TITLE
Update version and add autoupdate strategy

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -20,7 +20,7 @@ cpe = "cpe:2.3:a:borg_project:borg"
 fund = "https://www.borgbackup.org/support/fund.html"
 
 [integration]
-yunohost = ">= 11.0.9"
+yunohost = ">= 11.2.20"
 architectures = "all"
 multi_instance = true
 ldap = "not_relevant"

--- a/manifest.toml
+++ b/manifest.toml
@@ -105,5 +105,7 @@ ram.runtime = "50M"
         "libssl-dev",
         "liblz4-dev",
         "libfuse3-dev",
+        "libxxhash-dev",
+        "libzstd-dev",
         "pkg-config",
     ]

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,13 +7,15 @@ name = "Borg Backup"
 description.en = "Regularly create deduplicated, encrypted backups sent to another server using Borg"
 description.fr = "Créez régulièrement des sauvegardes dédupliquées et chiffées envoyées sur un autre serveur à l'aide de Borg"
 
-version = "1.2.8~ynh2"
+version = "1.4.0~ynh1"
 
 maintainers = ["ljf"]
 
 [upstream]
 license = "BSD-3-Clause"
-website = "https://borgbackup.readthedocs.io"
+website = "https://www.borgbackup.org"
+admindoc = "https://borgbackup.readthedocs.io"
+code = "https://github.com/borgbackup/borg"
 cpe = "cpe:2.3:a:borg_project:borg"
 fund = "https://www.borgbackup.org/support/fund.html"
 
@@ -77,6 +79,15 @@ ram.runtime = "50M"
     default = "errors_only"
 
 [resources]
+    [resources.sources]
+
+        [resources.sources.main]
+        url = "https://github.com/borgbackup/borg/releases/download/1.4.0/borgbackup-1.4.0.tar.gz"
+        sha256 = "c54c45155643fa66fed7f9ff2d134ea0a58d0ac197c18781ddc2fb236bf6ed29"
+        autoupdate.strategy = "latest_github_release"
+        autoupdate.asset = "^borgbackup-.*.tar.gz)$"
+        prefetch = false
+
     [resources.system_user]
 
     [resources.install_dir]

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -13,7 +13,6 @@ install_borg_with_pip () {
     venvpy="$install_dir/venv/bin/python3"
 
     ynh_exec_as "$app" "$venvpy" -m pip install --upgrade setuptools wheel
-    
     BORG_VERSION=$(ynh_app_upstream_version)
     ynh_exec_as "$app" "$venvpy" -m pip install borgbackup[pyfuse3]=="$BORG_VERSION"
 }

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -13,7 +13,8 @@ install_borg_with_pip () {
     venvpy="$install_dir/venv/bin/python3"
 
     ynh_exec_as "$app" "$venvpy" -m pip install --upgrade setuptools wheel
-
+    ynh_exec_as "$app" "$venvpy" -m pip install pkgconfig
+    
     BORG_VERSION=$(ynh_app_upstream_version)
     ynh_exec_as "$app" "$venvpy" -m pip install borgbackup[pyfuse3]=="$BORG_VERSION"
 }

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -13,7 +13,6 @@ install_borg_with_pip () {
     venvpy="$install_dir/venv/bin/python3"
 
     ynh_exec_as "$app" "$venvpy" -m pip install --upgrade setuptools wheel
-    ynh_exec_as "$app" "$venvpy" -m pip install pkgconfig
     
     BORG_VERSION=$(ynh_app_upstream_version)
     ynh_exec_as "$app" "$venvpy" -m pip install borgbackup[pyfuse3]=="$BORG_VERSION"


### PR DESCRIPTION
## Problem

Version 1.4.0 has been released. https://github.com/borgbackup/borg/releases/tag/1.4.0 Also, in `install_borg_with_pip` the version is retrieved with `ynh_app_upstream_version` although there was no upstream version defined (if I understand it correctly)? See https://github.com/YunoHost-Apps/borg_ynh/blob/master/scripts/_common.sh#L17

## Solution

So, I updated the version. I also added the borg source from GitHub to have an autoupdate strategy. As borg is still installed with pip I set `prefetch=false`.

Edit: Also added some missing APT sources from https://borgbackup.readthedocs.io/en/stable/installation.html#debian-ubuntu

- libzstd-devel
- xxhash-devel

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
