### PR TITLE
Properly handle "borg create" status code which maybe be "1" when warning occurs (such as when a file changed during the backup)

### DIFF
--- a/conf/backup_method
+++ b/conf/backup_method
@@ -53,7 +53,7 @@ This is an automated message from your beloved YunoHost server." | /usr/bin/mail
         # This is a warning, the script may continue, but let's warn the admin.
         # See: https://github.com/borgbackup/borg/issues/6989#issuecomment-1223921392
         echo "Some warning were logged during the backup, you'd probably check whether it was severe or not" >&2
-    # Note that retco
+    # Note that retcode is greater or equal to 2, which means the "borg create" command failed. Exit in such a case.
     elif [[ "${retcode:-}" != 0 ]]
     then
         exit $retcode

--- a/conf/backup_method
+++ b/conf/backup_method
@@ -46,20 +46,18 @@ This is an automated message from your beloved YunoHost server." | /usr/bin/mail
     # About the {now} placeholder:
     # https://borgbackup.readthedocs.io/en/stable/usage/create.html#description
     # In the archive name, you may use the following placeholders: {now}, {utcnow}, {fqdn}, {hostname}, {user} and some others.
-    "$borg" create --stats "::${name}-{now}" "$work_dir" || status=$?
+    "$borg" create --stats "::${name}-{now}" "$work_dir" && retcode="0" || retcode="$?"
     # Check whether the above command exit with a return code > 0
-    case "$status" in
-      "") # return code was 0, skip
-        ;;
-      "1")
+    if [[ "${retcode:-}" == 1 ]]
+    then
         # This is a warning, the script may continue, but let's warn the admin.
         # See: https://github.com/borgbackup/borg/issues/6989#issuecomment-1223921392
         echo "Some warning were logged during the backup, you'd probably check whether it was severe or not" >&2
-        ;;
-      *)
-        exit $status
-        ;;
-    esac
+    # Note that retco
+    elif [[ "${retcode:-}" != 0 ]]
+    then
+        exit $retcode
+    fi
 
     "$borg" prune --glob-archives "${name}-*" --list --keep-hourly 2 --keep-daily=7 --keep-weekly=8 --keep-monthly=12
 

--- a/conf/backup_method
+++ b/conf/backup_method
@@ -46,7 +46,20 @@ This is an automated message from your beloved YunoHost server." | /usr/bin/mail
     # About the {now} placeholder:
     # https://borgbackup.readthedocs.io/en/stable/usage/create.html#description
     # In the archive name, you may use the following placeholders: {now}, {utcnow}, {fqdn}, {hostname}, {user} and some others.
-    "$borg" create --stats "::${name}-{now}" "$work_dir"
+    "$borg" create --stats "::${name}-{now}" "$work_dir" || status=$?
+    # Check whether the above command exit with a return code > 0
+    case "$status" in
+      "") # return code was 0, skip
+        ;;
+      "1")
+        # This is a warning, the script may continue, but let's warn the admin.
+        # See: https://github.com/borgbackup/borg/issues/6989#issuecomment-1223921392
+        echo "Some warning were logged during the backup, you'd probably check whether it was severe or not" >&2
+        ;;
+      *)
+        exit $status
+        ;;
+    esac
 
     "$borg" prune --glob-archives "${name}-*" --list --keep-hourly 2 --keep-daily=7 --keep-weekly=8 --keep-monthly=12
 


### PR DESCRIPTION
## Problem

Fixes #159 ?

If a file has changed during the backup, the admin gets a warning and the `borg create` command exists with status code 1. This code is meant to raise attention about an issue that may not be severe:
https://github.com/borgbackup/borg/commit/7e6afc93e918bc5549e8bd4d4153d1a47bc32566

## Solution

I propose to check the status code and exit only it is equal to 2 or above.

Also see this comment, which should solve the warning (I still think my patch would probably be helpful anyway for other cases): https://github.com/YunoHost-Apps/synapse_ynh/issues/474#issuecomment-2198321405

Please note that I haven't tested it yet. I encounter the issue on production, I would like to get a review and I would be glad to beta test it afterward.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable) ⇒ see above

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
