### PR TITLE
Strip `$work_dir` from paths inside the backup archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This app is the "client" part, meant to be installed on the server to be backed 
 Maybe counter-intuitively, you should *first* install this app (`borg_ynh`) and *then* (`borgserver_ynh`) on the other machine. In fact, at the end of the install of `borg_ynh`, you will be provided with the info, in particular the SSH public key, to be used to setup `borgserver_ynh` on the other machine.
 
 
-**Shipped version:** 1.4.0~ynh2
+**Shipped version:** 1.4.0~ynh3
 ## Documentation and resources
 
 - Official app website: <https://www.borgbackup.org>

--- a/README_es.md
+++ b/README_es.md
@@ -36,7 +36,7 @@ This app is the "client" part, meant to be installed on the server to be backed 
 Maybe counter-intuitively, you should *first* install this app (`borg_ynh`) and *then* (`borgserver_ynh`) on the other machine. In fact, at the end of the install of `borg_ynh`, you will be provided with the info, in particular the SSH public key, to be used to setup `borgserver_ynh` on the other machine.
 
 
-**Versión actual:** 1.4.0~ynh2
+**Versión actual:** 1.4.0~ynh3
 ## Documentaciones y recursos
 
 - Sitio web oficial: <https://www.borgbackup.org>

--- a/README_eu.md
+++ b/README_eu.md
@@ -36,7 +36,7 @@ This app is the "client" part, meant to be installed on the server to be backed 
 Maybe counter-intuitively, you should *first* install this app (`borg_ynh`) and *then* (`borgserver_ynh`) on the other machine. In fact, at the end of the install of `borg_ynh`, you will be provided with the info, in particular the SSH public key, to be used to setup `borgserver_ynh` on the other machine.
 
 
-**Paketatutako bertsioa:** 1.4.0~ynh2
+**Paketatutako bertsioa:** 1.4.0~ynh3
 ## Dokumentazioa eta baliabideak
 
 - Aplikazioaren webgune ofiziala: <https://www.borgbackup.org>

--- a/README_fr.md
+++ b/README_fr.md
@@ -36,7 +36,7 @@ This app is the "client" part, meant to be installed on the server to be backed 
 Maybe counter-intuitively, you should *first* install this app (`borg_ynh`) and *then* (`borgserver_ynh`) on the other machine. In fact, at the end of the install of `borg_ynh`, you will be provided with the info, in particular the SSH public key, to be used to setup `borgserver_ynh` on the other machine.
 
 
-**Version incluse :** 1.4.0~ynh2
+**Version incluse :** 1.4.0~ynh3
 ## Documentations et ressources
 
 - Site officiel de l’app : <https://www.borgbackup.org>

--- a/README_gl.md
+++ b/README_gl.md
@@ -36,7 +36,7 @@ This app is the "client" part, meant to be installed on the server to be backed 
 Maybe counter-intuitively, you should *first* install this app (`borg_ynh`) and *then* (`borgserver_ynh`) on the other machine. In fact, at the end of the install of `borg_ynh`, you will be provided with the info, in particular the SSH public key, to be used to setup `borgserver_ynh` on the other machine.
 
 
-**Versión proporcionada:** 1.4.0~ynh2
+**Versión proporcionada:** 1.4.0~ynh3
 ## Documentación e recursos
 
 - Web oficial da app: <https://www.borgbackup.org>

--- a/README_id.md
+++ b/README_id.md
@@ -36,7 +36,7 @@ This app is the "client" part, meant to be installed on the server to be backed 
 Maybe counter-intuitively, you should *first* install this app (`borg_ynh`) and *then* (`borgserver_ynh`) on the other machine. In fact, at the end of the install of `borg_ynh`, you will be provided with the info, in particular the SSH public key, to be used to setup `borgserver_ynh` on the other machine.
 
 
-**Versi terkirim:** 1.4.0~ynh2
+**Versi terkirim:** 1.4.0~ynh3
 ## Dokumentasi dan sumber daya
 
 - Website aplikasi resmi: <https://www.borgbackup.org>

--- a/README_nl.md
+++ b/README_nl.md
@@ -36,7 +36,7 @@ This app is the "client" part, meant to be installed on the server to be backed 
 Maybe counter-intuitively, you should *first* install this app (`borg_ynh`) and *then* (`borgserver_ynh`) on the other machine. In fact, at the end of the install of `borg_ynh`, you will be provided with the info, in particular the SSH public key, to be used to setup `borgserver_ynh` on the other machine.
 
 
-**Geleverde versie:** 1.4.0~ynh2
+**Geleverde versie:** 1.4.0~ynh3
 ## Documentatie en bronnen
 
 - Officiele website van de app: <https://www.borgbackup.org>

--- a/README_pl.md
+++ b/README_pl.md
@@ -36,7 +36,7 @@ This app is the "client" part, meant to be installed on the server to be backed 
 Maybe counter-intuitively, you should *first* install this app (`borg_ynh`) and *then* (`borgserver_ynh`) on the other machine. In fact, at the end of the install of `borg_ynh`, you will be provided with the info, in particular the SSH public key, to be used to setup `borgserver_ynh` on the other machine.
 
 
-**Dostarczona wersja:** 1.4.0~ynh2
+**Dostarczona wersja:** 1.4.0~ynh3
 ## Dokumentacja i zasoby
 
 - Oficjalna strona aplikacji: <https://www.borgbackup.org>

--- a/README_ru.md
+++ b/README_ru.md
@@ -36,7 +36,7 @@ This app is the "client" part, meant to be installed on the server to be backed 
 Maybe counter-intuitively, you should *first* install this app (`borg_ynh`) and *then* (`borgserver_ynh`) on the other machine. In fact, at the end of the install of `borg_ynh`, you will be provided with the info, in particular the SSH public key, to be used to setup `borgserver_ynh` on the other machine.
 
 
-**Поставляемая версия:** 1.4.0~ynh2
+**Поставляемая версия:** 1.4.0~ynh3
 ## Документация и ресурсы
 
 - Официальный веб-сайт приложения: <https://www.borgbackup.org>

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -36,7 +36,7 @@ This app is the "client" part, meant to be installed on the server to be backed 
 Maybe counter-intuitively, you should *first* install this app (`borg_ynh`) and *then* (`borgserver_ynh`) on the other machine. In fact, at the end of the install of `borg_ynh`, you will be provided with the info, in particular the SSH public key, to be used to setup `borgserver_ynh` on the other machine.
 
 
-**分发版本：** 1.4.0~ynh2
+**分发版本：** 1.4.0~ynh3
 ## 文档与资源
 
 - 官方应用网站： <https://www.borgbackup.org>

--- a/conf/backup_method
+++ b/conf/backup_method
@@ -46,7 +46,9 @@ This is an automated message from your beloved YunoHost server." | /usr/bin/mail
     # About the {now} placeholder:
     # https://borgbackup.readthedocs.io/en/stable/usage/create.html#description
     # In the archive name, you may use the following placeholders: {now}, {utcnow}, {fqdn}, {hostname}, {user} and some others.
-    "$borg" create --stats "::${name}-{now}" "$work_dir" && retcode="0" || retcode="$?"
+    pushd "$work_dir"
+       "$borg" create --stats "::${name}-{now}" . && retcode="0" || retcode="$?"
+    popd
     # Check whether the above command exit with a return code > 0
     if [[ "${retcode:-}" == 1 ]]
     then

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Borg Backup"
 description.en = "Regularly create deduplicated, encrypted backups sent to another server using Borg"
 description.fr = "Créez régulièrement des sauvegardes dédupliquées et chiffées envoyées sur un autre serveur à l'aide de Borg"
 
-version = "1.4.0~ynh2"
+version = "1.4.0~ynh3"
 
 maintainers = ["ljf"]
 


### PR DESCRIPTION
## Problem

- https://forum.yunohost.org/t/borg-restore-backup-file-without-info-json/31979/1

## Solution

- `pushd $work_dir`, back up `.` (hence stripping `$work_dir` from resulting tar)

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
