### PR TITLE
Improved error and success emails formating, and included missing general borg logs in them

### DIFF
--- a/conf/backup-with-borg
+++ b/conf/backup-with-borg
@@ -91,7 +91,7 @@ $(cat $err_file)
 
 
 **********************************************
-Additional global ${borg_id} app logs:
+Last logs in global ${borg_id} log file:
 **********************************************
 $(tail -n 50 "/var/log/${borg_id}/borg.log")
 **********************************************

--- a/conf/backup-with-borg
+++ b/conf/backup-with-borg
@@ -26,6 +26,7 @@ sudo yunohost app setting "${borg_id}" state -v "ongoing"
 # Backup system part conf
 conf=$(sudo yunohost app setting "${borg_id}" conf)
 if [[ "$conf" = "1" ]]; then
+    # run yunohost backup using custom method specified in "backup_method" script
     if ! sudo yunohost backup create -n auto_conf --method "${borg_id}_app" --system $(filter_hooks conf) 2>> "$err_file" >> "$log_file" ; then
         errors+="\nThe backup miserably failed to backup system configurations."
     fi
@@ -34,6 +35,7 @@ fi
 # Backup system data
 data=$(sudo yunohost app setting "${borg_id}" data)
 if [[ "$data" = "1" ]]; then
+    # run yunohost backup using custom method specified in "backup_method" script
     if ! sudo yunohost backup create -n auto_data --method "${borg_id}_app" --system $(filter_hooks data) 2>> "$err_file" >> "$log_file" ; then
         errors+="\nThe backup miserably failed to backup system data."
     fi
@@ -54,6 +56,7 @@ for application in $(sudo ls /etc/yunohost/apps/); do
         continue
     fi
 
+    # run yunohost backup using custom method specified in "backup_method" script
     if ! sudo yunohost backup create -n "auto_$application" --method "${borg_id}_app" --apps "$application" 2>> "$err_file" >> "$log_file" ; then
         errors+="\nThe backup miserably failed to backup $application application."
     fi
@@ -62,6 +65,58 @@ done
 #=========================================================
 # SEND MAIL TO NOTIFY ABOUT SUCCEEDED OR FAILED OPERATIONS
 #=========================================================
+
+sendErrorEmail() {
+
+    MAIL_CONTENT=$(echo -e "
+There's been an error while backing up your beloved YunoHost server.
+
+
+$errors
+
+
+
+**********************************************
+Here are info logs from the operation:
+**********************************************
+$(cat $log_file)
+**********************************************
+
+
+**********************************************
+Here are error logs from the operation:
+**********************************************
+$(cat $err_file)
+**********************************************
+
+
+**********************************************
+Additional global ${borg_id} app logs:
+**********************************************
+$(tail -n 50 "/var/log/${borg_id}/borg.log")
+**********************************************
+    ")
+
+    echo -e "$MAIL_CONTENT" | mail -a "Content-Type: text/plain; charset=UTF-8" -s "[borg] Backup failed from $domain onto $repository" root
+
+}
+
+sendSuccessEmail() {
+
+    MAIL_CONTENT=$(echo -e "
+Your beloved YunoHost server has been successfully backed up.
+
+
+**********************************************
+Here are info logs from the operation:
+**********************************************
+$(cat $log_file)
+**********************************************
+    ")
+
+    echo -e "$MAIL_CONTENT" | mail -a "Content-Type: text/plain; charset=UTF-8" -s "[borg] Backup succeeded from $domain onto $repository" root
+
+}
 
 partial_errors="$(cat "$log_file" | grep -E "Error|Skipped")"
 if [ -n "$partial_errors" ]; then
@@ -79,9 +134,9 @@ else
 fi
 
 if [[ -n "$errors" && $mailalert != "never" ]]; then
-    cat <(echo -e "$errors\n\n\n") "$log_file" "$err_file" | mail -a "Content-Type: text/plain; charset=UTF-8" -s "[borg] Backup failed from $domain onto $repository" root
+    sendErrorEmail
     exit 1
 elif [ "$mailalert" == "always" ]; then
-    cat "$log_file" | mail -a "Content-Type: text/plain; charset=UTF-8" -s "[borg] Backup succeeded from $domain onto $repository" root
+    sendSuccessEmail
     exit 0
 fi


### PR DESCRIPTION
## Problem

1. There are missing logs in the error email sent to admins, for example, if a repo's quota has been reached, this is logged in the general `/var/log/borg/borg.log`, and not in the operation log, so the admin won't see about it in the email and therefore have a harder time figuring out why backup failed.
2. Emails could be more clear, there are logs from two different files but it looks like one single log, so one does not understand the chronology of the logs.

## Solution

1. Include last logs from `/var/borg/<app>/borg.log` in error emails.
2. Improved the formatting of sent emails.

Fixes #191

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
