### PR TITLE
Add support for the remote-path borg option

### DIFF
--- a/conf/backup_method
+++ b/conf/backup_method
@@ -14,6 +14,10 @@ else
     BORG_RSH="ssh -i /root/.ssh/id_${app}_ed25519 -oStrictHostKeyChecking=no "
 fi
 
+if [[ "$(yunohost app setting "$app" remote-path)" != "" ]]; then
+    BORG_REMOTE_PATH="$(yunohost app setting "$app" remote-path)"
+fi
+
 do_need_mount() {
     true
 }
@@ -24,6 +28,7 @@ do_backup() {
     export BORG_RSH
     export BORG_LOGGING_CONF
     export BORG_RELOCATED_REPO_ACCESS_IS_OK=yes
+    export BORG_REMOTE_PATH
     work_dir="$1"
     name="$2"
     size="$3"
@@ -72,6 +77,7 @@ do_mount() {
     export BORG_REPO
     export BORG_RSH
     export BORG_LOGGING_CONF
+    export BORG_REMOTE_PATH
     work_dir="$1"
     name="$2"
     size="$3"

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -30,6 +30,13 @@ export BORG_RSH="ssh -i /root/.ssh/id_${app}_ed25519 -oStrictHostKeyChecking=yes
 repository="$(sudo yunohost app setting $app repository)"
 ```
 
+If additional options are needed, like the *remote path* to the borg executable, set them as well:
+```bash
+if [[ "$(sudo yunohost app setting $app remote-path)" != "" ]]; then
+    export BORG_REMOTE_PATH="$(sudo yunohost app setting $app remote-path)"
+fi
+```
+
 Then run for example:
 
 - List archives: `borg list "$repository" | less`

--- a/scripts/config
+++ b/scripts/config
@@ -49,8 +49,16 @@ get__data_multimedia() {
 get__last_backups() {
     cat << EOF
 ask: |-
+EOF
+    if [ "$(ynh_app_setting_get $app remote-path)" != "" ]; then
+        cat << EOF
+$(BORG_PASSPHRASE="$(ynh_app_setting_get $app passphrase)" BORG_RSH="ssh -i /root/.ssh/id_${app}_ed25519 -oStrictHostKeyChecking=yes " BORG_REMOTE_PATH="$(ynh_app_setting_get $app remote-path)" "$borg" list --short --last 50 ${old[repository]} | sed 's/^/  /g' 2> /dev/null)
+EOF
+    else
+        cat << EOF
 $(BORG_PASSPHRASE="$(ynh_app_setting_get $app passphrase)" BORG_RSH="ssh -i /root/.ssh/id_${app}_ed25519 -oStrictHostKeyChecking=yes " "$borg" list --short --last 50 ${old[repository]} | sed 's/^/  /g' 2> /dev/null)
 EOF
+fi
 }
 
 get__conf() {


### PR DESCRIPTION
## Problem

Addresses the need to support the borg remote-path option (see https://github.com/YunoHost-Apps/borg_ynh/issues/120)

## Solution

With the following changes, borg will be executed with the `BORG_REMOTE_PATH` env var set to the value of the `remote-path` setting of the borg app.

One may set the remote path option with `yunohost app setting borg remote-path -v borg1234`. This would lead to borg being run with something equivalent to `borg --remote-path borg1234`

It would probably be better with a proper config value in the admin panel, but that's a bit beyond my current skills... and not sure this should be useful.

Maybe the current way to go, with an optional setting, would be enough for most needs, as I expect the need for remote-path to be quite rare. 

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

