### PR TITLE
Provide title for second config panel

### DIFF
--- a/config_panel.toml
+++ b/config_panel.toml
@@ -1,6 +1,7 @@
 version = "1.0"
 
 [main]
+name = "Backups configuration"
 services = []
 
     [main.state]


### PR DESCRIPTION
## Problem

The configuration panel just displays a wrench icon, without any title.

This makes it a bit confusing at first, since we only get titles for the left-most and right-most, and nothing in the middle

## PR Status

- [X] Code finished and ready to be reviewed/tested
