### PR TITLE
Refer to the docs in post-install, as variables are displayed empty

### DIFF
--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -1,3 +1,30 @@
+## Allowing borg to connect to remote server via SSH
+
+If you selected a remote borg server as backup target (*starting with `ssh://`*), borg will connect to it with SSH using a SSH public key that was generated for that purpose during this app installation.
+
+In principle, you'll only need to provide that SSH public key to the remote server administrator so that remote backups can be performed.
+
+### Installing "Borg server" on a remote yunohost server
+
+Chances are you wish to use the "Borg server" app if the remote server runs Yunohost.
+
+You should then install the "Borg Server" app there, with the following credentials (you may need to send this to your friend):
+
+- Remote user: *the USER, as set in `ssh://USER@DOMAIN.TLD:PORT/~/backup`*
+- SSH Public key: *as displayed in the config panel above*
+
+Or directly using command line on the remote server:
+
+`yunohost app install https://github.com/YunoHost-Apps/borgserver_ynh -a "ssh_user=USER&public_key=PUBLIC_KEY"`
+
+NB: the SSH user is not meant to pre-exist on the server on which borgserver is installed!
+
+### Configuring SSH access on other remote Borg servers
+
+Alternatively, any remote Borg repository could be used, even if not running on yunohost, provided the local borg is able to connect via SSH.
+
+You'll then need to make sure the corresponding SSH public key (*as displayed in the config panel above*) is installed on the remote account (adding this public key to `~USER/.ssh/authorized_keys` on the remote server).
+
 ## Reminder regarding the passphrase
 
 The passphrase is the only way to decrypt your backups. You should make sure to keep it safe in some place "outside" your server to cover the scenario where your server is destroyed for some reason.

--- a/doc/POST_INSTALL.md
+++ b/doc/POST_INSTALL.md
@@ -1,12 +1,5 @@
-You should check out the admin documentation of this app after installation for more info!
+You defined the backup target: `__REPOSITORY__`.
 
-If you selected a remote borg server as backup target, you should now install the "Borg Server" app on `__SERVER__` and with the following credentials (you may need to send this to your friend):
+You should check out the admin documentation of this app at the bottom of the config panel!
 
-- User: `__SSH_USER__`
-- Public key: `__PUBLIC_KEY__`
-
-Or directly using command line:
-
-`yunohost app install https://github.com/YunoHost-Apps/borgserver_ynh -a "ssh_user=__SSH_USER__&public_key=__PUBLIC_KEY__"`
-
-NB: the SSH user is not meant to pre-exist on the server on which borgserver is installed!
+If you selected a remote borg server as backup target (*starting with `ssh://`*), you'll be interested by some additional suggestions (you should now probably install the "Borg Server" Yunohost app on that remote server, or configure SSH access to the remote account using the SSH public key that was just generated during install).


### PR DESCRIPTION
## Problem

This addresses #203. There's no more a way (I think) to split the "repository" config value in USER, SERVER, etc. so the post-install notice is broken.

Variables must have changed and post-install docs didn't adjust to the change.

## Solution

Only display the configured value for "repository", and provide the suggestion to go read the admin docs.

The instructions about the borg server install, and use of the public key are then transferred to the admin docs (so that they aren't forgotten when one dismisses the post-install notice).

Along the way I add a bit more details, as not everyone will use borg with the borg server app on another YunoHost server.

## PR Status

- [X] Code finished and ready to be reviewed/tested
