### PR TITLE
Remove autoupdate.upstream

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -86,7 +86,6 @@ ram.runtime = "50M"
     prefetch = false
 
     autoupdate.strategy = "latest_github_release"
-    autoupdate.upstream = "https://github.com/borgbackup/borg"
 
     [resources.system_user]
 


### PR DESCRIPTION
## Problem

- Autoupdate does not work.

## Solution

Not 100% sure.

My suspicion is that autoupdate.upstream prevent it somehow to work correctly (a bug in the apptools?).

Also it does not seem necessary as the URL of the source points to the github repository.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
