### PR TITLE
Fix get calendar config

### DIFF
--- a/scripts/config
+++ b/scripts/config
@@ -10,8 +10,12 @@ borg="$install_dir/venv/bin/borg"
 # SPECIFIC GETTERS FOR TOML SHORT KEY
 #=================================================
 
+get__on_calendar() {
+    ynh_app_setting_get --app="$app" --key="on_calendar"
+}
+
 get__info() {
-        cat << EOF
+    cat << EOF
 ask:
   en: "**Backup state:** ${old[state]}
 
@@ -46,6 +50,7 @@ get__data_multimedia() {
         echo "value: true"
     fi
 }
+
 get__last_backups() {
     local backup_list=$(BORG_PASSPHRASE="$(ynh_app_setting_get $app passphrase)" BORG_RSH="ssh -i /root/.ssh/id_${app}_ed25519 -oStrictHostKeyChecking=yes " "$borg" list --short --last 50 ${old[repository]} 2> /dev/null)
     if [ -z "$backup_list" ]; then


### PR DESCRIPTION
## Problem

Report from a user:
> Hello there! I have a problem with the setup of Borg, the web ui is simply not saving my changes. Especially the periodicity field stays empty, so I cannot schedule the backups. Do you know if I can edit the setup via the terminal?

Indeed, prior to this patch, the frequency was not displayed.

## Solution

A getter was missing, given that we bind the corresponding property in the config panel to `"null"`

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
