### PR TITLE
Limit borg logs retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 Regularly create deduplicated, encrypted backups sent to another server using Borg
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://www.borgbackup.org)
-[![Version: 1.4.1~ynh1](https://img.shields.io/badge/Version-1.4.1~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/borg/)
+[![Version: 1.4.1~ynh2](https://img.shields.io/badge/Version-1.4.1~ynh2-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/borg/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/borg"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/conf/backup-with-borg
+++ b/conf/backup-with-borg
@@ -17,11 +17,24 @@ filter_hooks() {
     sudo ls /usr/share/yunohost/hooks/backup/ /etc/yunohost/hooks.d/backup/ | grep "\-$1_" | cut -d"-" -f2 | uniq 2>> "$err_file"
 }
 
+healthchecks_url="$(sudo yunohost app setting "${borg_id}" healthchecks_url)"
+healthcheck() {
+    if [[ -n "$healthchecks_url" ]]; then
+        local signal="$1"
+        # the expression "${signal:+/$signal}" adds a leading slash to the value of $signal 
+        # only if the latter is not empty, otherwise it returns an empty string.
+        local url="$healthchecks_url${signal:+/$signal}"
+        curl -s -m 10 -o /dev/null --data-raw "$(echo $2 | tail --bytes=10000)" "$url"
+    fi
+}
+
 fail_if_partially_failed() {
     grep Skipped|Error
 }
 sudo yunohost app setting "${borg_id}" last_run -v "${current_date}"
 sudo yunohost app setting "${borg_id}" state -v "ongoing"
+
+healthcheck "start"
 
 # Backup system part conf
 conf=$(sudo yunohost app setting "${borg_id}" conf)
@@ -74,8 +87,10 @@ repository="$(sudo yunohost app setting "${borg_id}" repository)"
 mailalert="$(sudo yunohost app setting "${borg_id}" mailalert)"
 if [[ -n "$errors" ]]; then
     sudo yunohost app setting "${borg_id}" state -v "failed"
+    healthcheck "fail" "$errors"
 else
     sudo yunohost app setting "${borg_id}" state -v "successful"
+    healthcheck
 fi
 
 if [[ -n "$errors" && $mailalert != "never" ]]; then

--- a/conf/backup_method
+++ b/conf/backup_method
@@ -65,6 +65,11 @@ This is an automated message from your beloved YunoHost server." | /usr/bin/mail
 
     # We prune potential manual backup older than 1 year
     "$borg" prune --list --keep-within 1y
+
+    # Compact repo after pruning it, otherwise in fact nothing will be really removed from the repo,
+    # making its actual size grow disproportionately compared to what `borg info` displays
+    # See: https://github.com/borgbackup/borg/issues/6106#issuecomment-1215449050
+    "$borg" compact
 }
 
 do_mount() {

--- a/conf/systemd-cleanup-logs.service
+++ b/conf/systemd-cleanup-logs.service
@@ -1,0 +1,47 @@
+[Unit]
+Description=Clean up __APP__ logs
+After=
+
+[Service]
+Type=oneshot
+ExecCondition=/bin/test -n "__LOGS_RETENTION__"
+ExecStart=/usr/bin/find /var/log/__APP__/ -regex '/var/log/__APP__/[0-9]+_[0-9]+.\(log\|err\)' -mtime +__LOGS_RETENTION__ -delete
+User=root
+Group=root
+
+### Depending on specificities of your service/app, you may need to tweak these
+### .. but this should be a good baseline
+# Sandboxing options to harden security
+# Details for these options: https://www.freedesktop.org/software/systemd/man/systemd.exec.html
+NoNewPrivileges=yes
+PrivateTmp=yes
+PrivateDevices=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+RestrictNamespaces=yes
+RestrictRealtime=yes
+DevicePolicy=closed
+ProtectClock=yes
+ProtectHostname=yes
+ProtectProc=invisible
+ProtectSystem=full
+ProtectControlGroups=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+LockPersonality=yes
+SystemCallArchitectures=native
+SystemCallFilter=~@clock @debug @module @mount @obsolete @reboot @setuid @swap @cpu-emulation @privileged
+
+# Denying access to capabilities that should not be relevant for webapps
+# Doc: https://man7.org/linux/man-pages/man7/capabilities.7.html
+CapabilityBoundingSet=~CAP_RAWIO CAP_MKNOD
+CapabilityBoundingSet=~CAP_AUDIT_CONTROL CAP_AUDIT_READ CAP_AUDIT_WRITE
+CapabilityBoundingSet=~CAP_SYS_BOOT CAP_SYS_TIME CAP_SYS_MODULE CAP_SYS_PACCT
+CapabilityBoundingSet=~CAP_LEASE CAP_LINUX_IMMUTABLE CAP_IPC_LOCK
+CapabilityBoundingSet=~CAP_BLOCK_SUSPEND CAP_WAKE_ALARM
+CapabilityBoundingSet=~CAP_SYS_TTY_CONFIG
+CapabilityBoundingSet=~CAP_MAC_ADMIN CAP_MAC_OVERRIDE
+CapabilityBoundingSet=~CAP_NET_ADMIN CAP_NET_BROADCAST CAP_NET_RAW
+CapabilityBoundingSet=~CAP_SYS_ADMIN CAP_SYS_PTRACE CAP_SYSLOG
+
+[Install]
+WantedBy=multi-user.target

--- a/conf/systemd-cleanup-logs.timer
+++ b/conf/systemd-cleanup-logs.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Run __APP__ log cleanup regularly
+
+[Timer]
+OnCalendar=Weekly
+
+[Install]
+WantedBy=timers.target

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -29,7 +29,7 @@ name.fr = "Configuration de Borg"
         type = "string"
         help.en = "Specify a local repository (`/mount/my_external_harddrive/backups`) or a remote repository (`ssh://USER@DOMAIN.TLD:PORT/~/backup`). If you plan to use a remote borgserver_ynh app: `USER` is *not* meant to be an existing user on the guest server, instead, it will be created *on the host server* during the installation of the Borg Server App. With the Borg Server App, you can't specify another repo path than `~/backup`."
         help.fr = "Spécifier un dépôt local (`/mount/my_external_harddrive/backups`) ou un dépôt distant (`ssh://USER@DOMAIN.TLD:PORT/~/backup`). Si vous prévoyez d’utiliser une application borgserver_ynh distante : `USER` n'est *pas* censé être un utilisateur existant sur le serveur invité, il sera créé *sur le serveur hôte* lors de l’installation de l'application Borg Server. Avec l'application Borg Server, vous ne pouvez pas spécifier un autre chemin de dépôt que `~/backup`."
-  
+
         [main.general.ssh_public_key]
         ask.en = "Public key"
         ask.fr = "Clé publique"
@@ -42,7 +42,7 @@ name.fr = "Configuration de Borg"
         type = "string"
         help.en = "For example: `Monthly`, `Weekly`, `Daily` (=every day at midnight), `Hourly`, `Sat *-*-1..7 18:00:00` (=the first saturday of every month at 18:00), `4:00` (=every day at 4 AM), `5,17:00` (=every day at 5 AM and 5 PM). See the [systemd OnCalendar format for full syntax doc](https://wiki.archlinux.org/index.php/Systemd/Timers#Realtime_timer)"
         bind = "null"
-        
+
         [main.general.mailalert]
         ask.en = "Mail alert"
         ask.fr = "Alerte mail"
@@ -52,7 +52,7 @@ name.fr = "Configuration de Borg"
         choices.never = "Never alert me"
         help.en = "Alerts are sent to members of the admins group"
         help.fr = "Les alertes sont envoyées aux membres du groupe admins"
-        
+
     [main.content]
     name.en = "What should be backed up?"
     name.fr = "Que faut-il sauvegarder ?"
@@ -79,6 +79,18 @@ name.fr = "Configuration de Borg"
         type = "tags"
         help.en = "App list separated by comma. You can write 'all' to select all apps, even those installed after this Borg app. You can also select all apps but some apps by writing 'exclude:' following by an app list separated by comma."
         help.fr = "Liste d'applications séparées par des virgules. Vous pouvez écrire 'all' pour sélectionner toutes les applications, même celles installées après cette application Borg. Vous pouvez également sélectionner toutes les applications, mais certaines applications en précédant par 'exclude:' une liste d’applications séparées par des virgules."
+
+    [main.advanced]
+    name = "Advanced settings"
+    optional = true
+
+        [main.advanced.healthchecks_url]
+        ask.en = "Monitoring URL (Healthchecks)"
+        ask.fr = "URL de monitoring (Healthchecks)"
+        type = "url"
+        help.en = "Use a monitor service to detect silent failures. It's optional and currently meant to work with Healthchecks. If you don't know what it is, just leave it blank or look it up to this service: https://healthchecks.io"
+        help.fr = "Utiliser un service de monitoring pour détecter les échecs silencieux. C'est optionnel et actuellement destiné à fonctionner avec Healthchecks. Si vous ne connaissez pas, vous pouvez ignorer ou jeter un œil à ce service: https://healthchecks.io"
+        optional = true
 
 [list]
 name.en = "Last backups list"

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -92,6 +92,13 @@ name.fr = "Configuration de Borg"
         help.fr = "Utiliser un service de monitoring pour détecter les échecs silencieux. C'est optionnel et actuellement destiné à fonctionner avec Healthchecks. Si vous ne connaissez pas, vous pouvez ignorer ou jeter un œil à ce service: https://healthchecks.io"
         optional = true
 
+        [main.advanced.logs_retention]
+        ask.en = "Logs retention (in days)"
+        ask.fr = "Rétention des logs (en jours)"
+        type = "number"
+        min = 0
+        optional = true
+
 [list]
 name.en = "Last backups list"
 name.fr = "Liste des dernières sauvegardes"

--- a/manifest.toml
+++ b/manifest.toml
@@ -95,6 +95,7 @@ ram.runtime = "50M"
 
     [resources.apt]
     packages = [
+        "curl",
         "python3-pip",
         "python3-dev",
         "python3-jinja2",

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Borg Backup"
 description.en = "Regularly create deduplicated, encrypted backups sent to another server using Borg"
 description.fr = "Créez régulièrement des sauvegardes dédupliquées et chiffées envoyées sur un autre serveur à l'aide de Borg"
 
-version = "1.4.1~ynh1"
+version = "1.4.1~ynh2"
 
 maintainers = ["ljf"]
 

--- a/scripts/config
+++ b/scripts/config
@@ -47,10 +47,15 @@ get__data_multimedia() {
     fi
 }
 get__last_backups() {
-    cat << EOF
+    local backup_list=$(BORG_PASSPHRASE="$(ynh_app_setting_get $app passphrase)" BORG_RSH="ssh -i /root/.ssh/id_${app}_ed25519 -oStrictHostKeyChecking=yes " "$borg" list --short --last 50 ${old[repository]} 2> /dev/null)
+    if [ -z "$backup_list" ]; then
+        echo 'ask: "*no backups yet*"'
+    else
+        cat << EOF
 ask: |-
-$(BORG_PASSPHRASE="$(ynh_app_setting_get $app passphrase)" BORG_RSH="ssh -i /root/.ssh/id_${app}_ed25519 -oStrictHostKeyChecking=yes " "$borg" list --short --last 50 ${old[repository]} | sed 's/^/  /g' 2> /dev/null)
+$(sed 's/^/  /g' <<< "$backup_list")
 EOF
+    fi
 }
 
 get__conf() {

--- a/scripts/config
+++ b/scripts/config
@@ -10,8 +10,12 @@ borg="$install_dir/venv/bin/borg"
 # SPECIFIC GETTERS FOR TOML SHORT KEY
 #=================================================
 
+get__on_calendar() {
+    ynh_app_setting_get --app="$app" --key="on_calendar"
+}
+
 get__info() {
-        cat << EOF
+    cat << EOF
 ask:
   en: "**Backup state:** ${old[state]}
 
@@ -46,6 +50,7 @@ get__data_multimedia() {
         echo "value: true"
     fi
 }
+
 get__last_backups() {
     local backup_list=$(BORG_PASSPHRASE="$(ynh_app_setting_get $app passphrase)" BORG_RSH="ssh -i /root/.ssh/id_${app}_ed25519 -oStrictHostKeyChecking=yes " "$borg" list --short --last 50 ${old[repository]} 2> /dev/null)
     if [ -z "$backup_list" ]; then

--- a/scripts/config
+++ b/scripts/config
@@ -103,6 +103,12 @@ set__on_calendar() {
     systemctl daemon-reload
 }
 
+set__logs_rentention() {
+    ynh_app_setting_set --app="$app" --key="logs_retention" --value="$logs_retention"
+    ynh_add_systemd_config --service="$app-cleanup-logs.service" --template="systemd-cleanup-logs.service"
+    systemctl daemon-reload
+}
+
 #=================================================
 # GENERIC FINALIZATION
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -39,6 +39,8 @@ ynh_app_setting_set --app=$app --key=healthchecks_url --value=""
 # passwords aren't saved by default
 ynh_app_setting_set --app=$app --key=passphrase --value="$passphrase"
 
+ynh_app_setting_set --app=$app --key=cleanup_logs_older_than --value="365"
+
 #=================================================
 # INSTALL BORG
 #=================================================
@@ -99,6 +101,16 @@ systemctl disable $app.service --quiet
 ynh_add_config --template="systemd.timer" --destination="/etc/systemd/system/$app.timer"
 systemctl enable $app.timer --quiet
 systemctl start $app.timer
+
+# Create a systemd job to cleanup the log files
+ynh_add_systemd_config --service="$app-cleanup-logs.service" --template="systemd-cleanup-logs.service"
+yunohost service add $app-cleanup-logs --description="Cleanup logs for $app" --log "/var/log/$app/cleanup-logs.log"
+systemctl disable $app-cleanup-logs.service --quiet
+
+# Configure the systemd timer
+ynh_add_config --template="systemd-cleanup-logs.timer" --destination="/etc/systemd/system/$app-cleanup-logs.timer"
+systemctl enable $app-cleanup-logs.timer --quiet
+systemctl start $app-cleanup-logs.timer
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/install
+++ b/scripts/install
@@ -34,6 +34,8 @@ ynh_app_setting_set --app=$app --key=state --value="$state"
 last_run="-"
 ynh_app_setting_set --app=$app --key=last_run --value="$last_run"
 
+ynh_app_setting_set --app=$app --key=healthchecks_url --value=""
+
 # passwords aren't saved by default
 ynh_app_setting_set --app=$app --key=passphrase --value="$passphrase"
 

--- a/scripts/install
+++ b/scripts/install
@@ -39,7 +39,7 @@ ynh_app_setting_set --app=$app --key=healthchecks_url --value=""
 # passwords aren't saved by default
 ynh_app_setting_set --app=$app --key=passphrase --value="$passphrase"
 
-ynh_app_setting_set --app=$app --key=cleanup_logs_older_than --value="365"
+ynh_app_setting_set --app=$app --key=logs_retention --value="365"
 
 #=================================================
 # INSTALL BORG

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -30,6 +30,9 @@ if [[ "${mailalert:-}" != "always" && "${mailalert:-}" != "errors_only" && "${ma
     ynh_app_setting_set --app=$app --key="mailalert" --value="errors_only"
     export mailalert="errors_only"
 fi
+if [ -z "${healthchecks_url:-}" ]; then
+    ynh_app_setting_set --app=$app --key="healthchecks_url" --value=""
+fi
 ynh_app_setting_set --app=$app --key="state" --value="not run since last update"
 ynh_app_setting_set --app=$app --key="last_run" --value="-"
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -33,9 +33,13 @@ fi
 if [ -z "${healthchecks_url:-}" ]; then
     ynh_app_setting_set --app=$app --key="healthchecks_url" --value=""
 fi
+if [ -z "${logs_retention:-}" ]; then
+  logs_retention=""
+  ynh_app_setting_set --app=$app --key="logs_retention" --value=""
+fi
+
 ynh_app_setting_set --app=$app --key="state" --value="not run since last update"
 ynh_app_setting_set --app=$app --key="last_run" --value="-"
-ynh_app_setting_set --app=$app --key="cleanup_logs_older_than" --value="${cleanup_logs_older_than:-365}"
 
 if [ -z "$repository" ]; then
     repository="ssh://$ssh_user@$server/~/backup"
@@ -114,13 +118,24 @@ ynh_script_progression --message="Upgrading system configurations related to $ap
 
 # Create a dedicated systemd config
 ynh_add_systemd_config
-yunohost service add $app --description="Deduplicating backup program" --test_status="systemctl show $app.service  -p ActiveState --value | grep -v failed"  --log "/var/log/$app/borg.log"
+yunohost service add $app --description="Deduplicating backup program" --test_status="systemctl show $app.service -p ActiveState --value | grep -v failed"  --log "/var/log/$app/borg.log"
 # Disable the service, this is to prevent the service from being triggered at boot time
 systemctl disable $app.service --quiet
 
 ynh_add_config --template="systemd.timer" --destination="/etc/systemd/system/$app.timer"
 systemctl enable $app.timer --quiet
 systemctl start $app.timer
+
+# Create a systemd job to cleanup the log files
+ynh_add_systemd_config --service="$app-cleanup-logs" --template="systemd-cleanup-logs.service"
+yunohost service add $app-cleanup-logs --description="Cleanup logs for $app" --log "/var/log/$app/cleanup-logs.log" \
+  --test_status="systemctl show $app-cleanup-logs.service -p ActiveState --value | grep -v failed"
+systemctl disable $app-cleanup-logs.service --quiet
+
+# Configure the systemd timer
+ynh_add_config --template="systemd-cleanup-logs.timer" --destination="/etc/systemd/system/$app-cleanup-logs.timer"
+systemctl enable $app-cleanup-logs.timer --quiet
+systemctl start $app-cleanup-logs.timer
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -35,7 +35,7 @@ if [ -z "${healthchecks_url:-}" ]; then
 fi
 ynh_app_setting_set --app=$app --key="state" --value="not run since last update"
 ynh_app_setting_set --app=$app --key="last_run" --value="-"
-
+ynh_app_setting_set --app=$app --key="cleanup_logs_older_than" --value="${cleanup_logs_older_than:-365}"
 
 if [ -z "$repository" ]; then
     repository="ssh://$ssh_user@$server/~/backup"


### PR DESCRIPTION
## Problem

Fixes #218

## Solution

Have a systemd timer handle logs purge.

Still after having discussed about it with other contributors, I wonder if we should not rather have a bigger thought to think about how logs are created.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
