### PR TITLE
Document where to check for logs

### DIFF
--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -12,7 +12,9 @@ If you want to test correct Borg Apps setup before scheduled time, you can start
 systemctl start borg
 ```
 
-Once the backup completes, you can check that a backup is listed in the webadmin > Applications > Borg > 'Last backups list'.
+Once the backup completes, you can check that a backup is listed in the panel *webadmin > Applications > Borg > 'Last backups list'*.
+
+If you have a shell session, you will find more details on borg execution logs in `/var/log/borg/borg.log`
 
 ## Manually running `borg` commands
 


### PR DESCRIPTION
A tiny useful addition to be able to check logs in case of doubt

## Problem

Commands are provided to use borg if everything works, but in case of doubt there's few hints to troublecheck

## Solution

Moar docs

## PR Status

- [X ] Code finished and ready to be reviewed/tested

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
