### PR TITLE
Fixup config panel

### DIFF
--- a/scripts/config
+++ b/scripts/config
@@ -9,6 +9,7 @@ borg_with_env_vars="$install_dir/wrapper/borg"
 #=================================================
 
 get__on_calendar() {
+# YAML seems to hate systemd timer patterns like `*-*-* 03:30:00` so format custom YAML manually
     cat << EOF
     value: '$(ynh_app_setting_get --app="$app" --key="on_calendar")'
 EOF


### PR DESCRIPTION
## Problem

- Config panel is not displayed in Web Admin, `yunohost app config get borg` errors out with 

```
rror: Could not read return from hook /etc/yunohost/apps/borg/scripts/config. Error: Corrupted YAML read from /tmp/tmpamaxrgps/stdreturn: while scanning an alias
  in "<unicode string>", line 31, column 14:
          value: *-*-* 03:00:00
( .. yada yada ...)
```

## Solution

- Quote timer pattern for `on_calendar` and call it `value` to get an actual valid YAML

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
