### PR TITLE
Specify the exact format in the glob-archives arg

### DIFF
--- a/conf/backup_method
+++ b/conf/backup_method
@@ -61,7 +61,7 @@ This is an automated message from your beloved YunoHost server." | /usr/bin/mail
 
     # https://manpages.debian.org/testing/borgbackup/borg-placeholders.1.en.html
     # {now} is by default in ISO-8601 format. e.g. YYYY-MM-DDTHH:MM:SS
-    "$borg" prune --glob-archives "${name}-[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9]" --keep-hourly 2 --keep-daily=7 --keep-weekly=8 --keep-monthly=12
+    "$borg" prune --glob-archives "${name}-????-??-??T??:??:??" --keep-hourly 2 --keep-daily=7 --keep-weekly=8 --keep-monthly=12
 }
 
 do_mount() {


### PR DESCRIPTION
## Problem

- *I have `gitlab` and `gitlab-runner` on my server, the prune for `gitlab` `"${name}-*"` match both `gitlab` and `gitlab-runner`*

## Solution

- *Specify the exact format in the glob-archives arg*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
