### PR TITLE
Prune archives on per-app basis

### DIFF
--- a/conf/backup-with-borg
+++ b/conf/backup-with-borg
@@ -41,6 +41,8 @@ conf=$(sudo yunohost app setting "${borg_id}" conf)
 if [[ "$conf" = "1" ]]; then
     if ! sudo yunohost backup create -n auto_conf --method "${borg_id}_app" --system $(filter_hooks conf) 2>> "$err_file" >> "$log_file" ; then
         errors+="\nThe backup miserably failed to backup system configurations."
+    else
+        "$borg" prune --keep-within 1y --glob-archives "auto_conf-*"
     fi
 fi
 
@@ -49,6 +51,8 @@ data=$(sudo yunohost app setting "${borg_id}" data)
 if [[ "$data" = "1" ]]; then
     if ! sudo yunohost backup create -n auto_data --method "${borg_id}_app" --system $(filter_hooks data) 2>> "$err_file" >> "$log_file" ; then
         errors+="\nThe backup miserably failed to backup system data."
+    else
+        "$borg" prune --keep-within 1y --glob-archives "auto_data-*"
     fi
 fi
 
@@ -69,13 +73,12 @@ for application in $(sudo ls /etc/yunohost/apps/); do
 
     if ! sudo yunohost backup create -n "auto_$application" --method "${borg_id}_app" --apps "$application" 2>> "$err_file" >> "$log_file" ; then
         errors+="\nThe backup miserably failed to backup $application application."
+    else
+        "$borg" prune --keep-within 1y --glob-archives "auto_${application}-*"
     fi
 done
 
 borg="__INSTALL_DIR__/wrapper/borg"
-
-# We prune potential manual backup older than 1 year
-"$borg" prune --keep-within 1y
 
 # Compact repo after pruning it, otherwise in fact nothing will be really removed from the repo,
 # making its actual size grow disproportionately compared to what `borg info` displays


### PR DESCRIPTION
## Problem

- `borg prune` treats all archives equal, so it'll keep a collection of archives not necessarily for all archived apps.

Sample run with ~current script, archive is meant to keep YNH conf and data:

```
Keeping archive (rule: daily #1):            auto_data-2026-01-14T03:31:01        Wed, 2026-01-14 04:31:02 [67a9e761a7af64fae8f4f3992d30b607d1089081c5bb65814b6b3c4107353607]
Remote: Storage quota: 2.29 GB out of 3.66 TB used.
Pruning archive (1/30):                      auto_conf-2026-01-14T03:30:22        Wed, 2026-01-14 04:30:24 [46612793a5ff777fd8085724f1c19a06a12c3d50659ff2b829d624f166804373]
Pruning archive (2/30):                      auto_data-2026-01-13T03:31:02        Tue, 2026-01-13 04:31:04 [81b65b5d4da26087ef988f62a49e0df371088bddd8575327b14014819a9622c2]
Pruning archive (3/30):                      auto_conf-2026-01-13T03:30:22        Tue, 2026-01-13 04:30:24 [0dcf1bdc5d1cb5131466d313d221aff12bce1e2ca41df19a9c138e7af3e37ed5]
Pruning archive (4/30):                      auto_data-2026-01-12T03:31:10        Mon, 2026-01-12 04:31:12 [2747bcc56db04dab3ec5ac67ae43a00fb14ac9af48ac52b9d0686e3c96ecbf92]
Pruning archive (5/30):                      auto_conf-2026-01-12T03:30:28        Mon, 2026-01-12 04:30:30 [dec54058e57127f00f05bdc3fa713d31321fbdd2f9e5d00866fb7c7e6c44647e]
Keeping archive (rule: weekly #1):           auto_data-2026-01-11T03:31:06        Sun, 2026-01-11 04:31:08 [14ff60118cbcfb883bb4e64130980a066d1d28b5e1ab588a4b9d398a4a1a9b7a]
Pruning archive (6/30):                      auto_conf-2026-01-11T03:30:24        Sun, 2026-01-11 04:30:26 [2083072fd93f1b78cbd5b334a3dcbe036001220d5b22b2bc64b2981f509851ab]
```

## Solution

Add `--glob-archive` flag and run `borg prune` in a loop, sample run:

```
Pruning archives for: auto_data
Keeping archive (rule: daily #1):            auto_data-2026-01-14T03:31:01        Wed, 2026-01-14 04:31:02 [67a9e761a7af64fae8f4f3992d30b607d1089081c5bb65814b6b3c4107353607]
Remote: Storage quota: 2.29 GB out of 3.66 TB used.
Pruning archive (1/14):                      auto_data-2026-01-13T03:31:02        Tue, 2026-01-13 04:31:04 [81b65b5d4da26087ef988f62a49e0df371088bddd8575327b14014819a9622c2]
Pruning archive (2/14):                      auto_data-2026-01-12T03:31:10        Mon, 2026-01-12 04:31:12 [2747bcc56db04dab3ec5ac67ae43a00fb14ac9af48ac52b9d0686e3c96ecbf92]
Keeping archive (rule: weekly #1):           auto_data-2026-01-11T03:31:06        Sun, 2026-01-11 04:31:08 [14ff60118cbcfb883bb4e64130980a066d1d28b5e1ab588a4b9d398a4a1a9b7a]
Pruning archive (3/14):                      auto_data-2026-01-10T03:31:11        Sat, 2026-01-10 04:31:13 [5f31c11c52a91eab02f7d17f6f820d08b38da52de3cf9d985f903dd7049f6094]

.....

Pruning archives for: auto_conf
Keeping archive (rule: daily #1):            auto_conf-2026-01-14T03:30:22        Wed, 2026-01-14 04:30:24 [46612793a5ff777fd8085724f1c19a06a12c3d50659ff2b829d624f166804373]
Remote: Storage quota: 2.29 GB out of 3.66 TB used.
Pruning archive (1/13):                      auto_conf-2026-01-13T03:30:22        Tue, 2026-01-13 04:30:24 [0dcf1bdc5d1cb5131466d313d221aff12bce1e2ca41df19a9c138e7af3e37ed5]
Pruning archive (2/13):                      auto_conf-2026-01-12T03:30:28        Mon, 2026-01-12 04:30:30 [dec54058e57127f00f05bdc3fa713d31321fbdd2f9e5d00866fb7c7e6c44647e]
Keeping archive (rule: weekly #1):           auto_conf-2026-01-11T03:30:24        Sun, 2026-01-11 04:30:26 [2083072fd93f1b78cbd5b334a3dcbe036001220d5b22b2bc64b2981f509851ab]
Pruning archive (3/13):                      auto_conf-2026-01-10T03:30:28        Sat, 2026-01-10 04:30:29 [d5ec15d4f79977616511a82f621613e9b8b40fc777d1ebd273dce7f2ce965f1a]

...
```

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
