### PR TITLE
Change user server when editing repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 Regularly create deduplicated, encrypted backups sent to another server using Borg
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://www.borgbackup.org)
-[![Version: 1.4.4~ynh1](https://img.shields.io/badge/Version-1.4.4~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/borg/)
+[![Version: 1.4.4~ynh2](https://img.shields.io/badge/Version-1.4.4~ynh2-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/borg/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/borg"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/conf/backup_method
+++ b/conf/backup_method
@@ -10,7 +10,13 @@ set +a
 # Only take advantage of logging.conf here. Not meaningful for the wrapper typically.
 export BORG_LOGGING_CONF='__INSTALL_DIR__/logging.conf'
 
-if ! ssh-keygen -F "__SERVER__" >/dev/null ; then
+# We may just use _._SERVER_._ (without dots) here... But its value might have
+# changed if the administrator had modified the repository from the config panel.
+# At the contrary there is no reason for _._APP_._ (without dots) to change, so let's
+# take advantage of that and spare the regeneration of this file when modifying the repository.
+server=$(yunohost app setting "__APP__" "server")
+
+if ! ssh-keygen -F "$server" >/dev/null ; then
     export BORG_RSH="${BORG_RSH/oStrictHostKeyChecking=yes/oStrictHostKeyChecking=no}"
 fi
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Borg Backup"
 description.en = "Regularly create deduplicated, encrypted backups sent to another server using Borg"
 description.fr = "Créez régulièrement des sauvegardes dédupliquées et chiffées envoyées sur un autre serveur à l'aide de Borg"
 
-version = "1.4.4~ynh1"
+version = "1.4.4~ynh2"
 
 maintainers = ["ljf", "fflorent"]
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -4,6 +4,8 @@
 # COMMON VARIABLES AND CUSTOM HELPERS
 #=================================================
 
+ssh_regex='^ssh://([^@]*)@([^:/]*)(:[0-9]+)?/(.*)$'
+
 install_borg_with_pip () {
     # Install borg as root, to avoid privilege escalation as we run borg as root using sudo.
     # Assign the group to borg so it is able to execute the command but can't alter the binary.
@@ -29,4 +31,23 @@ _gen_and_save_public_key() {
     fi
 
     ynh_app_setting_set --key=public_key --value="$public_key"
+}
+
+save_user_and_server_from_repo() {
+    local repository="$1"
+
+    if [[ "$repository" =~ $ssh_regex ]]; then
+        ssh_user="${BASH_REMATCH[1]}"
+        server="${BASH_REMATCH[2]}"
+        port="${BASH_REMATCH[3]}"
+        if [[ -n "$port" ]]; then
+            server="[$server]$port"
+        fi
+    else
+        ssh_user=""
+        server=""
+    fi
+
+    ynh_app_setting_set --key=ssh_user --value="$ssh_user"
+    ynh_app_setting_set --key=server --value="$server"
 }

--- a/scripts/config
+++ b/scripts/config
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source _common.sh
+
 source /usr/share/yunohost/helpers
 
 borg_with_env_vars="$install_dir/wrapper/borg"
@@ -89,6 +91,7 @@ validate__on_calendar() {
 
 set__repository() {
     ynh_app_setting_set --key=repository --value="$repository"
+    save_user_and_server_from_repo "$repository"
     ynh_config_add --template="env.jinja" --destination="$install_dir/.env" --jinja
 }
 

--- a/scripts/install
+++ b/scripts/install
@@ -7,21 +7,7 @@ source /usr/share/yunohost/helpers
 # STORE SETTINGS FROM MANIFEST
 #=================================================
 
-ssh_regex='^ssh://([^@]*)@([^:/]*)(:[0-9]+)?/(.*)$'
-if [[ "$repository" =~ $ssh_regex ]]; then
-    ssh_user="${BASH_REMATCH[1]}"
-    server="${BASH_REMATCH[2]}"
-    port="${BASH_REMATCH[3]}"
-    if [[ -n "$port" ]]; then
-        server="[$server]$port"
-    fi
-else
-    ssh_user=""
-    server=""
-fi
-
-ynh_app_setting_set --key=ssh_user --value="$ssh_user"
-ynh_app_setting_set --key=server --value="$server"
+save_user_and_server_from_repo "$repository"
 
 state="repository uncreated"
 ynh_app_setting_set --key=state --value="$state"


### PR DESCRIPTION
## Problem


1. Install borg through the CLI, specifying a SSH location like ssh://some_user@localhost:22/~/backup
2. Press Enter when the post installation message appears, or at least
3. In the web admin, go to the installed app details, change repository so you change the username to some_user2. Validate
4. Go again to the app details, the post install notification should be displayed.

The problem: the user displayed is the old one (some_user), not the new one (some_user2)

⚠️ Also if you change the server in the repository, the server is not updated in the `backup_method` script.

## Solution

Fixes #255 

1. When editing the repository from the config panel, ensure that you extract the username and the server
2. Take advantage of the fact that `__APP__` cannot be modified after the installation to extract the `server` variable setting in `backup_method`, ensuring to retrieve the up to date value without regenerating the file.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
