### PR TITLE
Add pruning options

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 Regularly create deduplicated, encrypted backups sent to another server using Borg
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://www.borgbackup.org)
-[![Version: 1.4.4~ynh2](https://img.shields.io/badge/Version-1.4.4~ynh2-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/borg/)
+[![Version: 1.4.4~ynh3](https://img.shields.io/badge/Version-1.4.4~ynh3-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/borg/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/borg"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/conf/backup-with-borg
+++ b/conf/backup-with-borg
@@ -74,13 +74,16 @@ done
 
 borg="__INSTALL_DIR__/wrapper/borg"
 
-# We prune potential manual backup older than 1 year
-"$borg" prune --keep-within 1y
+if [ "$(sudo yunohost app setting "${borg_id}" "pruning_enabled")" != "false" ]; then
+    # We prune potential manual backup older than 1 year
+    keep_within="$(sudo yunohost app setting "${borg_id}" "keep_manual_within")"
+    "$borg" prune --keep-within "${keep_within:-1y}"
 
-# Compact repo after pruning it, otherwise in fact nothing will be really removed from the repo,
-# making its actual size grow disproportionately compared to what `borg info` displays
-# See: https://github.com/borgbackup/borg/issues/6106#issuecomment-1215449050
-"$borg" compact
+    # Compact repo after pruning it, otherwise in fact nothing will be really removed from the repo,
+    # making its actual size grow disproportionately compared to what `borg info` displays
+    # See: https://github.com/borgbackup/borg/issues/6106#issuecomment-1215449050
+    "$borg" compact
+fi
 
 #=========================================================
 # SEND MAIL TO NOTIFY ABOUT SUCCEEDED OR FAILED OPERATIONS

--- a/conf/backup_method
+++ b/conf/backup_method
@@ -20,6 +20,21 @@ if ! ssh-keygen -F "$server" >/dev/null ; then
     export BORG_RSH="${BORG_RSH/oStrictHostKeyChecking=yes/oStrictHostKeyChecking=no}"
 fi
 
+set_pruning_arguments() {
+    local -n args=$1
+    args=()
+    hourly=$(yunohost app setting "__APP__" "pruning_hourly")
+    daily=$(yunohost app setting "__APP__" "pruning_daily")
+    weekly=$(yunohost app setting "__APP__" "pruning_weekly")
+    monthly=$(yunohost app setting "__APP__" "pruning_monthly")
+    yearly=$(yunohost app setting "__APP__" "pruning_yearly")
+    args+=("--keep-hourly" "${hourly:-2}")
+    args+=("--keep-daily" "${daily:-7}")
+    args+=("--keep-weekly" "${weekly:-8}")
+    args+=("--keep-monthly" "${monthly:-12}")
+    args+=("--keep-yearly" "${monthly:-0}")
+}
+
 do_need_mount() {
     true
 }
@@ -65,9 +80,14 @@ This is an automated message from your beloved YunoHost server." | /usr/bin/mail
         exit $retcode
     fi
 
-    # https://manpages.debian.org/testing/borgbackup/borg-placeholders.1.en.html
-    # {now} is by default in ISO-8601 format. e.g. YYYY-MM-DDTHH:MM:SS
-    "$borg" prune --glob-archives "${name}-????-??-??T??:??:??" --keep-hourly 2 --keep-daily=7 --keep-weekly=8 --keep-monthly=12
+    if [ "$(yunohost app setting "__APP__" "pruning_enabled")" != "false" ]; then
+        local borg_prune_args
+        set_pruning_arguments borg_prune_args
+
+        # https://manpages.debian.org/testing/borgbackup/borg-placeholders.1.en.html
+        # {now} is by default in ISO-8601 format. e.g. YYYY-MM-DDTHH:MM:SS
+        "$borg" prune --glob-archives "${name}-????-??-??T??:??:??" "${borg_prune_args[@]}"
+    fi
 }
 
 do_mount() {

--- a/conf/backup_method
+++ b/conf/backup_method
@@ -32,7 +32,7 @@ set_pruning_arguments() {
     args+=("--keep-daily" "${daily:-7}")
     args+=("--keep-weekly" "${weekly:-8}")
     args+=("--keep-monthly" "${monthly:-12}")
-    args+=("--keep-yearly" "${monthly:-0}")
+    args+=("--keep-yearly" "${yearly:-0}")
 }
 
 do_need_mount() {

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -91,7 +91,7 @@ name.fr = "Paramètres avancés"
 
     [advanced.monitor]
     name.en = "Monitor backup health"
-    name.fr = "Superviser la santé des backups"
+    name.fr = "Superviser la santé des sauvegardes"
     optional = true
 
         [advanced.monitor.healthchecks_url]
@@ -166,7 +166,7 @@ name.fr = "Paramètres avancés"
 
         [advanced.pruning.keep_manual_within]
         ask.en = "Keep all manual backups within this interval"
-        ask.fr = "Garder toutes les backups manuelles selon cet intervalle"
+        ask.fr = "Garder toutes les sauvegardes manuelles selon cet intervalle"
         help.en = 'The interval should be of the following form: `<integer><character>`, where char is: “H” (hourly), “d” (daily), “w” (weekly), “m” (monthly), “y” (yearly).'
         help.fr = "L'intervalle doit être de la forme suivante: `<entier><caractère>`, où caractère est : “H” (*hourly* / horaire), “d” (*daily* / journalier), “w” (*weekly* / hebdomadaire), “m” (*monthly* / mensuel), “y” (*yearly* / annuel)."
         type = "string"

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -85,11 +85,16 @@ name.fr = "Configuration de Borg"
         help.en = "App list separated by comma. You can write 'all' to select all apps, even those installed after this Borg app. You can also select all apps but some apps by writing 'exclude:' following by an app list separated by comma."
         help.fr = "Liste d'applications séparées par des virgules. Vous pouvez écrire 'all' pour sélectionner toutes les applications, même celles installées après cette application Borg. Vous pouvez également sélectionner toutes les applications, mais certaines applications en précédant par 'exclude:' une liste d’applications séparées par des virgules."
 
-    [main.advanced]
-    name = "Advanced settings"
+[advanced]
+name.en = "Advanced settings"
+name.fr = "Paramètres avancés"
+
+    [advanced.monitor]
+    name.en = "Monitor backup health"
+    name.fr = "Superviser la santé des backups"
     optional = true
 
-        [main.advanced.healthchecks_url]
+        [advanced.monitor.healthchecks_url]
         ask.en = "Monitoring URL (Healthchecks)"
         ask.fr = "URL de monitoring (Healthchecks)"
         type = "url"
@@ -97,13 +102,86 @@ name.fr = "Configuration de Borg"
         help.fr = "Utiliser un service de monitoring pour détecter les échecs silencieux. C'est optionnel et actuellement destiné à fonctionner avec Healthchecks. Si vous ne connaissez pas, vous pouvez ignorer ou jeter un œil à ce service : https://healthchecks.io"
         optional = true
 
+    [advanced.pruning]
+    name.en = "Pruning of old backups"
+    name.fr = "Nettoyage des anciennes sauvegardes"
+    optional = true
+
+        [advanced.pruning.pruning_help]
+        type = "alert"
+        style = "info"
+        ask = """\
+        Take a look at the `borg prune` command documentation for more information: \n \
+        <https://borgbackup.readthedocs.io/en/stable/usage/prune.html>
+        """
+        # The following not seem to work:
+        # ask.fr = """\
+        # Lisez la documentation de la commande `borg prune` pour plus d'information (en anglais):
+        #
+        # https://borgbackup.readthedocs.io/en/stable/usage/prune.html
+        # """
+
+        [advanced.pruning.pruning_enabled]
+        ask.en = "Enable the pruning of the old backups"
+        ask.fr = "Activer le nettoyage des anciennes sauvegardes"
+        yes = "true"
+        no = "false"
+        type = "boolean"
+        default = true
+
+        [advanced.pruning.pruning_hourly]
+        ask.en = "Number of the latest hourly backups to keep"
+        ask.fr = "Nombre des dernières sauvegardes horaires à conserver"
+        type = "number"
+        default = 2
+        visible = "pruning_enabled"
+
+        [advanced.pruning.pruning_daily]
+        ask.en = "Number of the latest daily backups to keep"
+        ask.fr = "Nombre des dernières sauvegardes journalières à conserver"
+        type = "number"
+        default = 7
+        visible = "pruning_enabled"
+
+        [advanced.pruning.pruning_weekly]
+        ask.en = "Number of the latest weekly backups to keep"
+        ask.fr = "Nombre des dernières sauvegardes hebdomadaires à conserver"
+        type = "number"
+        default = 8
+        visible = "pruning_enabled"
+
+        [advanced.pruning.pruning_monthly]
+        ask.en = "Number of the latest monthly backups to keep"
+        ask.fr = "Nombre des dernières sauvegardes mensuelles à conserver"
+        type = "number"
+        default = 12
+        visible = "pruning_enabled"
+
+        [advanced.pruning.pruning_yearly]
+        ask.en = "Number of the latest yearly backups to keep"
+        ask.fr = "Nombre des dernières sauvegardes annuelles à conserver"
+        type = "number"
+        default = 0
+        visible = "pruning_enabled"
+
+        [advanced.pruning.keep_manual_within]
+        ask.en = "Keep all manual backups within this interval"
+        ask.fr = "Garder toutes les backups manuelles selon cet intervalle"
+        help.en = 'The interval should be of the following form: `<integer><character>`, where char is: “H” (hourly), “d” (daily), “w” (weekly), “m” (monthly), “y” (yearly).'
+        help.fr = "L'intervalle doit être de la forme suivante: `<entier><caractère>`, où caractère est : “H” (*hourly* / horaire), “d” (*daily* / journalier), “w” (*weekly* / hebdomadaire), “m” (*monthly* / mensuel), “y” (*yearly* / annuel)."
+        type = "string"
+        default = "1y"
+        pattern.regexp = '^\d+[Hdwmy]$'
+        pattern.error = 'The interval should be of the following form: “<integer><character>”, where char is “H” (hourly), “d” (daily), “w” (weekly), “m” (monthly), “y” (yearly).'
+        visible = "pruning_enabled"
+
 [list]
 name.en = "Last backups list"
 name.fr = "Liste des dernières sauvegardes"
 
     [list.list]
     name = ""
-    
+
         [list.list.last_backups]
         ask = ""
         type = "markdown"

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Borg Backup"
 description.en = "Regularly create deduplicated, encrypted backups sent to another server using Borg"
 description.fr = "Créez régulièrement des sauvegardes dédupliquées et chiffées envoyées sur un autre serveur à l'aide de Borg"
 
-version = "1.4.4~ynh2"
+version = "1.4.4~ynh3"
 
 maintainers = ["ljf", "fflorent"]
 


### PR DESCRIPTION
## Problem

There is no way to configure how borg prunes the backups (in other word, the retention of the backups)

Fixes #141 

## Solution

- Add an option to enable the pruning (enable by default)
- Add options to prune automatic backups (the defaults is the same as the previous behavior)
- Allow to configure the pruning of the manual backups (default unchanged, which is `1y`)

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
