### PR TITLE
Display instructions for remote repo only when necessary in post install

### DIFF
--- a/doc/POST_INSTALL.md
+++ b/doc/POST_INSTALL.md
@@ -1,6 +1,7 @@
 You should check out the admin documentation of this app after installation for more info!
 
-If you selected a remote borg server as backup target, you should now install the "Borg Server" app on `__SERVER__` and with the following credentials (you may need to send this to your friend):
+{% if ssh_user %}
+As you selected a remote borg server as backup target, you should now install the "Borg Server" app on `__SERVER__` and with the following credentials (you may need to send this to your friend):
 
 - User: `__SSH_USER__`
 - Public key: `__PUBLIC_KEY__`
@@ -10,3 +11,4 @@ Or directly using command line:
 `yunohost app install https://github.com/YunoHost-Apps/borgserver_ynh -a "ssh_user=__SSH_USER__&public_key=__PUBLIC_KEY__"`
 
 NB: the SSH user is not meant to pre-exist on the server on which borgserver is installed!
+{% endif %}


### PR DESCRIPTION
## Problem

Fixes https://github.com/YunoHost-Apps/borg_ynh/issues/203
Superseeds https://github.com/YunoHost-Apps/borg_ynh/pull/208

## Solution

Use jinja templates. See: https://github.com/YunoHost-Apps/borg_ynh/pull/208#discussion_r2279674898

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
