### PR TITLE
Remove SSH keys on purge, inform users otherwise

### DIFF
--- a/scripts/remove
+++ b/scripts/remove
@@ -35,6 +35,22 @@ ynh_safe_rm "/etc/systemd/system/$app.timer"
 ynh_safe_rm "/etc/yunohost/hooks.d/backup_method/05-${app}_app"
 
 #=================================================
+# REMOVE THE SSH KEYS
+#=================================================
+
+if [ "${YNH_APP_PURGE:-0}" -eq "1" ]; then
+    ynh_script_progression "Removing the SSH keys installed by $app..."
+    ynh_safe_rm "/root/.ssh/id_${app}_ed25519"
+    ynh_safe_rm "/root/.ssh/id_${app}_ed25519.pub"
+else
+    # Feeling like
+    ynh_print_info "Removal without purge, keeping the SSH keys '/root/.ssh/id_${app}_ed25519' and '/root/.ssh/id_${app}_ed25519.pub'"
+    ynh_print_info "You might be interested in deleting them (to prevent access to the backup repository), do that manually."
+    ynh_print_info "But please be sure you would still be able to retrieve your backups before doing so."
+fi
+
+
+#=================================================
 # END OF SCRIPT
 #=================================================
 


### PR DESCRIPTION
## Problem

Fixes #238 

## Solution

On removal:
- when `--purge` is activated, remove the SSH keys
- otherwise, leave information message for the users

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
