### PR TITLE
Change passphrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 Regularly create deduplicated, encrypted backups sent to another server using Borg
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://www.borgbackup.org)
-[![Version: 1.4.5~ynh3](https://img.shields.io/badge/Version-1.4.5~ynh3-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/borg/)
+[![Version: 1.4.5~ynh4](https://img.shields.io/badge/Version-1.4.5~ynh4-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/borg/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/borg"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -36,6 +36,21 @@ name.fr = "Configuration de Borg"
         type = "string"
         readonly = true
 
+        [main.general.change_passphrase]
+        ask.en = "Change the backup passphrase"
+        ask.fr = "Modifier le phrase de passe des sauvegardes"
+        type = "boolean"
+        bind = "null"
+
+        [main.general.new_passphrase]
+        ask.en = "Fill your new passphrase (NEEDS TO BE STRONG)"
+        ask.fr = "Renseignez votre nouvelle phrase de passe (DOIT ÊTRE ROBUSTE)"
+        type = "password"
+        bind = "null"
+        help.en = "Keep it safe! There will be **no way** to restore your backup if you lose it. Do not communicate it to the remote host server holder, or anyone else."
+        help.fr = "Gardez-la précieusement ! Il sera **impossible** de restaurer vos sauvegardes sans celle-ci. Elle est destinée à rester **secrète** : ne la donnez **pas** à la personne qui gère le serveur distant - où à n'importe qui d'autre !"
+        visible = "change_passphrase"
+
         [main.general.remote_path]
         ask.en = "Remote borg command (remote-path)"
         type = "string"

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Borg Backup"
 description.en = "Regularly create deduplicated, encrypted backups sent to another server using Borg"
 description.fr = "Créez régulièrement des sauvegardes dédupliquées et chiffées envoyées sur un autre serveur à l'aide de Borg"
 
-version = "1.4.5~ynh3"
+version = "1.4.5~ynh4"
 
 maintainers = ["ljf", "fflorent"]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -42,7 +42,7 @@ ram.runtime = "50M"
 
     [install.passphrase]
     ask.en = "Provide a strong passphrase to encrypt your backups. No blank space"
-    ask.fr = "Indiquez une phrase de passe forte pour chiffrer vos sauvegardes. Sans espaces"
+    ask.fr = "Indiquez une phrase de passe robuste pour chiffrer vos sauvegardes. Sans espaces"
     help.en = "Keep it safe! There will be **no way** to restore your backup if you lose it. Do not communicate it to the remote host server holder, or anyone else."
     help.fr = "Gardez-la précieusement ! Il sera **impossible** de restaurer vos sauvegardes sans celle-ci. Elle est destinée à rester **secrète** : ne la donnez **pas** à la personne qui gère le serveur distant - où à n'importe qui d'autre !"
     type = "password"

--- a/manifest.toml
+++ b/manifest.toml
@@ -41,8 +41,8 @@ ram.runtime = "50M"
     example = "ssh://john@serverb.tld:22/~/backup"
 
     [install.passphrase]
-    ask.en = "Provide a strong passphrase to encrypt your backups. No blank space"
-    ask.fr = "Indiquez une phrase de passe robuste pour chiffrer vos sauvegardes. Sans espaces"
+    ask.en = "Provide a strong passphrase to encrypt your backups"
+    ask.fr = "Indiquez une phrase de passe robuste pour chiffrer vos sauvegardes"
     help.en = "Keep it safe! There will be **no way** to restore your backup if you lose it. Do not communicate it to the remote host server holder, or anyone else."
     help.fr = "Gardez-la précieusement ! Il sera **impossible** de restaurer vos sauvegardes sans celle-ci. Elle est destinée à rester **secrète** : ne la donnez **pas** à la personne qui gère le serveur distant - où à n'importe qui d'autre !"
     type = "password"

--- a/scripts/config
+++ b/scripts/config
@@ -57,9 +57,6 @@ get__data_multimedia() {
 get__last_backups() {
 
     local backup_list
-    # Source the env file inside the command substitution ("$(...)")
-    # so the variables don't pollute the rest of the function and of the script.
-    # Indeed the command substitution spawns a subshell which is convenient here.
     backup_list=$(ynh_exec_as_app "$borg_with_env_vars" list --short --last 50 "${repository}" 2> /dev/null)
 
     if [ -z "$backup_list" ]; then
@@ -121,6 +118,22 @@ set__on_calendar() {
 set__remote_path() {
     ynh_app_setting_set --key=remote_path --value="$remote_path"
     ynh_config_add --template="env.jinja" --destination="$install_dir/.env" --jinja
+}
+
+set__new_passphrase() {
+    if [ -n "${new_passphrase}" ]; then
+        (
+            set -eEux -o pipefail
+            set -a
+            source "${install_dir}/.env"
+            BORG_NEW_PASSPHRASE="${new_passphrase}" "${install_dir}/venv/bin/borg" key change-passphrase
+        )
+        ynh_app_setting_set --key=passphrase --value="${new_passphrase}"
+        # store the new value into the `passphrase` variable so the template for `.env`
+        # takes the changes into account
+        passphrase="${new_passphrase}"
+        ynh_config_add --template="env.jinja" --destination="${install_dir}/.env" --jinja
+    fi
 }
 
 #=================================================


### PR DESCRIPTION
## Problem

1. It needs some tricky steps to change a passphrase (not only run the `key change-passphrase` command but also change the value in the settings and regenerate the `.env` file)
2. The passphrase can contain whitespaces now, as we surround the value with quotes in the `.env` file. I tested that.

Fixes #257 
Fixes #237 

## Solution

### Regarding the modification of the passphrase:
- Add a switch (a boolean field) in the config panel to prevent unwanted modifications
- Add a passphrase modification field, hidden until the previous field is enabled, to fill a new passphrase
- When the passphrase is provided and the changes validated, call the `borg key change-passphrase` command and store its new value in the app settings and in the env file as well

BTW, it looks like the check for common passwords works out of the box, which is a great feature 😍
https://github.com/YunoHost/yunohost/blob/622991f4a559caee626f2d14567883ef52fc6364/src/utils/form.py#L871

<img width="1262" height="56" alt="Screenshot showing an error when a common password is chosen as the new borg passphrase in the config panel." src="https://github.com/user-attachments/assets/ef6cddf2-0484-4e18-85ca-f33c04dbaa39" />

But unfortunately, it is not possible to change the passphrase through the cli:
```
# yunohost app config set borg main.general.new_passphrase -v WhatEverPassphrase

========================================
>>>> Borg configuration
========================================
Traceback (most recent call last):
  File "/usr/bin/yunohost", line 108, in <module>
    main()
  File "/usr/bin/yunohost", line 97, in main
    yunohost.cli(
  .......
  File "/usr/lib/python3/dist-packages/yunohost/utils/form.py", line 224, in evaluate_simple_js_expression
    return evaluate_simple_ast(node, context)  # type: ignore
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/yunohost/utils/form.py", line 109, in evaluate_simple_ast
    return context[node.id]
           ~~~~~~~^^^^^^^^^
KeyError: 'change_passphrase'
```

### About the blank space
Also remove the mention in the manifest regarding the blank spaces.

If I am correct, it is not necessary anymore:
```
# mkdir /tmp/backups
# yunohost app install borg -a "repository=/tmp/backups&passphrase=Hello world'works with quotes as well'&conf=0&data=0&apps=borg&on_calendar=Yearly&mailalert=never"
# chown borg__6: /tmp/backups/
# systemctl start APP_ID
# yunohost app shell APP_ID

$ borg list # Will list the backups successfully
```
And if you try to enter the passphrase manually:
```
$ cat .env
# ⚠️ This file is readonly and not meant to be edited: any changes will be lost at the next upgrade.
# Configure the borg app through the webadmin or run the relevant command lines instead to change values.
# https://doc.yunohost.org/en/admin/apps/#application-configuration

BORG_PASSPHRASE='Hello world'"'"'works with quotes as well'"'"''
BORG_REPO='/tmp/backups'
BORG_RELOCATED_REPO_ACCESS_IS_OK='yes'
BORG_RSH='ssh -i /root/.ssh/id_borg__6_ed25519 -oStrictHostKeyChecking=yes '
$ export BORG_REPO='/tmp/backups'
$ export BORG_RELOCATED_REPO_ACCESS_IS_OK='yes'
$ export BORG_RSH='ssh -i /root/.ssh/id_borg__6_ed25519 -oStrictHostKeyChecking=yes '
$ sudo ./venv/bin/borg list # Will ask for the passphrase, enter `Hello world'works with quotes as well'` and it will work
```

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
